### PR TITLE
docs: fix doc import tablist switcher

### DIFF
--- a/doc-tasks.js
+++ b/doc-tasks.js
@@ -78,7 +78,7 @@ function buildImports(section) {
   section.description = section.description
     .replace(codeRegex, (match, className) => {
 
-      if (className === 'lang-js' && !match.includes('// exclude-tablist')) {
+      if (className === 'language-js' && !match.includes('// exclude-tablist')) {
         let globalImport = match.replace(importRegex, `let {$1} = kontra`);
         let esImport = match.replace(importRegex, `import {$1} from 'path/to/kontra.mjs'`);
         let bundlerImport = match;

--- a/doc-tasks.js
+++ b/doc-tasks.js
@@ -7,7 +7,7 @@ const fs = require('fs');
 
 const optionalRegex = /^\[.*\]$/;
 const kontraTypeRegex = /kontra\.(\w+)/g;
-const packageVersionRegex = /{{\s?packageVersion\s?}}/g;
+const packageVersionRegex = /__packageVersion__/g;
 const excludeCodeRegex = /\s*\/\/ exclude-code:start[\s\S]*?\/\/ exclude-code:end/g;
 const excludeScriptRegex = /\s*\/\/ exclude-script:start[\r\n]([\s\S]*?[\r\n])\/\/ exclude-script:end[\r\n]/g;
 const codeRegex =/<pre>[\s\S]*?<code class="(.*)">([\s\S]*?)<\/code><\/pre>/g;
@@ -309,14 +309,9 @@ let tags = {
       sectionName: tags.sectionName
     };
 
-    console.log('\n\n\n');
-    console.log('contents.toString():', contents.toString());
-
     parseComments(contents.toString(), this.tag.description, tagList, {
       pages: this.pages,
       sections: this.sections
-    }, function(block) {
-      console.log(block);
     });
   }
 };

--- a/doc-tasks.js
+++ b/doc-tasks.js
@@ -302,11 +302,21 @@ let tags = {
     let contents = fs.readFileSync(this.tag.description);
 
     let parseComments = require( path.join(require.resolve('livingcss'), '../lib/parseComments.js') );
-    let tags = require( path.join(require.resolve('livingcss'), '../lib/tags.js') );
+    let livingCSSTags = require( path.join(require.resolve('livingcss'), '../lib/tags.js') );
+    let tagList = {
+      ...livingCSSTags,
+      example: tags.example,
+      sectionName: tags.sectionName
+    };
 
-    parseComments(contents.toString(), this.tag.description, tags, {
+    console.log('\n\n\n');
+    console.log('contents.toString():', contents.toString());
+
+    parseComments(contents.toString(), this.tag.description, tagList, {
       pages: this.pages,
       sections: this.sections
+    }, function(block) {
+      console.log(block);
     });
   }
 };

--- a/docs/api/animation.html
+++ b/docs/api/animation.html
@@ -84,7 +84,7 @@
     </li>
     <li role="presentation"></li>
   </ul>
-  <section role="tabpanel" aria-labelledby=animation-global-tab data-tabpanel="global"><pre><code class="lang-js">let { SpriteSheet, Animation } = kontra;
+  <section role="tabpanel" aria-labelledby=animation-global-tab data-tabpanel="global"><pre><code class="language-js">let { SpriteSheet, Animation } = kontra;
 
 let image = new Image();
 image.src = &#39;assets/imgs/character_walk_sheet.png&#39;;
@@ -101,9 +101,8 @@ image.onload = function() {
     frames: [1,2,3,6],
     frameRate: 30
   });
-};
-</code></pre></section>
-  <section role="tabpanel" aria-labelledby=animation-es-tab data-tabpanel="es"><pre><code class="lang-js">import { SpriteSheet, Animation } from 'path/to/kontra.mjs';
+};</code></pre></section>
+  <section role="tabpanel" aria-labelledby=animation-es-tab data-tabpanel="es"><pre><code class="language-js">import { SpriteSheet, Animation } from 'path/to/kontra.mjs';
 
 let image = new Image();
 image.src = &#39;assets/imgs/character_walk_sheet.png&#39;;
@@ -120,9 +119,8 @@ image.onload = function() {
     frames: [1,2,3,6],
     frameRate: 30
   });
-};
-</code></pre></section>
-  <section role="tabpanel" aria-labelledby=animation-bundle-tab data-tabpanel="bundle"><pre><code class="lang-js">import { SpriteSheet, Animation } from &#39;kontra&#39;;
+};</code></pre></section>
+  <section role="tabpanel" aria-labelledby=animation-bundle-tab data-tabpanel="bundle"><pre><code class="language-js">import { SpriteSheet, Animation } from &#39;kontra&#39;;
 
 let image = new Image();
 image.src = &#39;assets/imgs/character_walk_sheet.png&#39;;
@@ -139,8 +137,7 @@ image.onload = function() {
     frames: [1,2,3,6],
     frameRate: 30
   });
-};
-</code></pre></section>
+};</code></pre></section>
 </div>
         <h3 id="title-Animation"><span class="visually-hidden">Animation</span> Parameters</span></h3>
         <dl aria-labelledby="title-Animation">

--- a/docs/api/assets.html
+++ b/docs/api/assets.html
@@ -81,7 +81,7 @@
     </li>
     <li role="presentation"></li>
   </ul>
-  <section role="tabpanel" aria-labelledby=assets-global-tab data-tabpanel="global"><pre><code class="lang-js">let { load } = kontra;
+  <section role="tabpanel" aria-labelledby=assets-global-tab data-tabpanel="global"><pre><code class="language-js">let { load } = kontra;
 
 load(
   &#39;assets/imgs/character.png&#39;,
@@ -91,9 +91,8 @@ load(
   // all assets have loaded
 }).catch(function(err) {
   // error loading an asset
-});
-</code></pre></section>
-  <section role="tabpanel" aria-labelledby=assets-es-tab data-tabpanel="es"><pre><code class="lang-js">import { load } from 'path/to/kontra.mjs';
+});</code></pre></section>
+  <section role="tabpanel" aria-labelledby=assets-es-tab data-tabpanel="es"><pre><code class="language-js">import { load } from 'path/to/kontra.mjs';
 
 load(
   &#39;assets/imgs/character.png&#39;,
@@ -103,9 +102,8 @@ load(
   // all assets have loaded
 }).catch(function(err) {
   // error loading an asset
-});
-</code></pre></section>
-  <section role="tabpanel" aria-labelledby=assets-bundle-tab data-tabpanel="bundle"><pre><code class="lang-js">import { load } from &#39;kontra&#39;;
+});</code></pre></section>
+  <section role="tabpanel" aria-labelledby=assets-bundle-tab data-tabpanel="bundle"><pre><code class="language-js">import { load } from &#39;kontra&#39;;
 
 load(
   &#39;assets/imgs/character.png&#39;,
@@ -115,8 +113,7 @@ load(
   // all assets have loaded
 }).catch(function(err) {
   // error loading an asset
-});
-</code></pre></section>
+});</code></pre></section>
 </div>
         
 
@@ -212,7 +209,7 @@ load(
     </li>
     <li role="presentation"></li>
   </ul>
-  <section role="tabpanel" aria-labelledby=audioassets-global-tab data-tabpanel="global"><pre><code class="lang-js">let { load, setAudioPath, audioAssets } = kontra;
+  <section role="tabpanel" aria-labelledby=audioassets-global-tab data-tabpanel="global"><pre><code class="language-js">let { load, setAudioPath, audioAssets } = kontra;
 
 load(&#39;/audio/music.ogg&#39;).then(function() {
   // Audio asset can be accessed by both
@@ -225,9 +222,8 @@ load(&#39;sound.ogg&#39;).then(function() {
   // Audio asset can be accessed by both
   // name: audioAssets[&#39;sound&#39;]
   // path: audioAssets[&#39;sound.ogg&#39;]
-});
-</code></pre></section>
-  <section role="tabpanel" aria-labelledby=audioassets-es-tab data-tabpanel="es"><pre><code class="lang-js">import { load, setAudioPath, audioAssets } from 'path/to/kontra.mjs';
+});</code></pre></section>
+  <section role="tabpanel" aria-labelledby=audioassets-es-tab data-tabpanel="es"><pre><code class="language-js">import { load, setAudioPath, audioAssets } from 'path/to/kontra.mjs';
 
 load(&#39;/audio/music.ogg&#39;).then(function() {
   // Audio asset can be accessed by both
@@ -240,9 +236,8 @@ load(&#39;sound.ogg&#39;).then(function() {
   // Audio asset can be accessed by both
   // name: audioAssets[&#39;sound&#39;]
   // path: audioAssets[&#39;sound.ogg&#39;]
-});
-</code></pre></section>
-  <section role="tabpanel" aria-labelledby=audioassets-bundle-tab data-tabpanel="bundle"><pre><code class="lang-js">import { load, setAudioPath, audioAssets } from &#39;kontra&#39;;
+});</code></pre></section>
+  <section role="tabpanel" aria-labelledby=audioassets-bundle-tab data-tabpanel="bundle"><pre><code class="language-js">import { load, setAudioPath, audioAssets } from &#39;kontra&#39;;
 
 load(&#39;/audio/music.ogg&#39;).then(function() {
   // Audio asset can be accessed by both
@@ -255,8 +250,7 @@ load(&#39;sound.ogg&#39;).then(function() {
   // Audio asset can be accessed by both
   // name: audioAssets[&#39;sound&#39;]
   // path: audioAssets[&#39;sound.ogg&#39;]
-});
-</code></pre></section>
+});</code></pre></section>
 </div>
           
         </section>
@@ -282,7 +276,7 @@ load(&#39;sound.ogg&#39;).then(function() {
     </li>
     <li role="presentation"></li>
   </ul>
-  <section role="tabpanel" aria-labelledby=dataassets-global-tab data-tabpanel="global"><pre><code class="lang-js">let { load, setDataPath, dataAssets } = kontra;
+  <section role="tabpanel" aria-labelledby=dataassets-global-tab data-tabpanel="global"><pre><code class="language-js">let { load, setDataPath, dataAssets } = kontra;
 
 load(&#39;assets/data/file.txt&#39;).then(function() {
   // Audio asset can be accessed by both
@@ -295,9 +289,8 @@ load(&#39;info.json&#39;).then(function() {
   // Audio asset can be accessed by both
   // name: dataAssets[&#39;info&#39;]
   // path: dataAssets[&#39;info.json&#39;]
-});
-</code></pre></section>
-  <section role="tabpanel" aria-labelledby=dataassets-es-tab data-tabpanel="es"><pre><code class="lang-js">import { load, setDataPath, dataAssets } from 'path/to/kontra.mjs';
+});</code></pre></section>
+  <section role="tabpanel" aria-labelledby=dataassets-es-tab data-tabpanel="es"><pre><code class="language-js">import { load, setDataPath, dataAssets } from 'path/to/kontra.mjs';
 
 load(&#39;assets/data/file.txt&#39;).then(function() {
   // Audio asset can be accessed by both
@@ -310,9 +303,8 @@ load(&#39;info.json&#39;).then(function() {
   // Audio asset can be accessed by both
   // name: dataAssets[&#39;info&#39;]
   // path: dataAssets[&#39;info.json&#39;]
-});
-</code></pre></section>
-  <section role="tabpanel" aria-labelledby=dataassets-bundle-tab data-tabpanel="bundle"><pre><code class="lang-js">import { load, setDataPath, dataAssets } from &#39;kontra&#39;;
+});</code></pre></section>
+  <section role="tabpanel" aria-labelledby=dataassets-bundle-tab data-tabpanel="bundle"><pre><code class="language-js">import { load, setDataPath, dataAssets } from &#39;kontra&#39;;
 
 load(&#39;assets/data/file.txt&#39;).then(function() {
   // Audio asset can be accessed by both
@@ -325,8 +317,7 @@ load(&#39;info.json&#39;).then(function() {
   // Audio asset can be accessed by both
   // name: dataAssets[&#39;info&#39;]
   // path: dataAssets[&#39;info.json&#39;]
-});
-</code></pre></section>
+});</code></pre></section>
 </div>
           
         </section>
@@ -352,7 +343,7 @@ load(&#39;info.json&#39;).then(function() {
     </li>
     <li role="presentation"></li>
   </ul>
-  <section role="tabpanel" aria-labelledby=imageassets-global-tab data-tabpanel="global"><pre><code class="lang-js">let { load, setImagePath, imageAssets } = kontra;
+  <section role="tabpanel" aria-labelledby=imageassets-global-tab data-tabpanel="global"><pre><code class="language-js">let { load, setImagePath, imageAssets } = kontra;
 
 load(&#39;assets/imgs/character.png&#39;).then(function() {
   // Image asset can be accessed by both
@@ -365,9 +356,8 @@ load(&#39;character_walk_sheet.png&#39;).then(function() {
   // Image asset can be accessed by both
   // name: imageAssets[&#39;character_walk_sheet&#39;]
   // path: imageAssets[&#39;character_walk_sheet.png&#39;]
-});
-</code></pre></section>
-  <section role="tabpanel" aria-labelledby=imageassets-es-tab data-tabpanel="es"><pre><code class="lang-js">import { load, setImagePath, imageAssets } from 'path/to/kontra.mjs';
+});</code></pre></section>
+  <section role="tabpanel" aria-labelledby=imageassets-es-tab data-tabpanel="es"><pre><code class="language-js">import { load, setImagePath, imageAssets } from 'path/to/kontra.mjs';
 
 load(&#39;assets/imgs/character.png&#39;).then(function() {
   // Image asset can be accessed by both
@@ -380,9 +370,8 @@ load(&#39;character_walk_sheet.png&#39;).then(function() {
   // Image asset can be accessed by both
   // name: imageAssets[&#39;character_walk_sheet&#39;]
   // path: imageAssets[&#39;character_walk_sheet.png&#39;]
-});
-</code></pre></section>
-  <section role="tabpanel" aria-labelledby=imageassets-bundle-tab data-tabpanel="bundle"><pre><code class="lang-js">import { load, setImagePath, imageAssets } from &#39;kontra&#39;;
+});</code></pre></section>
+  <section role="tabpanel" aria-labelledby=imageassets-bundle-tab data-tabpanel="bundle"><pre><code class="language-js">import { load, setImagePath, imageAssets } from &#39;kontra&#39;;
 
 load(&#39;assets/imgs/character.png&#39;).then(function() {
   // Image asset can be accessed by both
@@ -395,8 +384,7 @@ load(&#39;character_walk_sheet.png&#39;).then(function() {
   // Image asset can be accessed by both
   // name: imageAssets[&#39;character_walk_sheet&#39;]
   // path: imageAssets[&#39;character_walk_sheet.png&#39;]
-});
-</code></pre></section>
+});</code></pre></section>
 </div>
           
         </section>
@@ -422,7 +410,7 @@ load(&#39;character_walk_sheet.png&#39;).then(function() {
     </li>
     <li role="presentation"></li>
   </ul>
-  <section role="tabpanel" aria-labelledby=load-global-tab data-tabpanel="global"><pre><code class="lang-js">let { load } = kontra;
+  <section role="tabpanel" aria-labelledby=load-global-tab data-tabpanel="global"><pre><code class="language-js">let { load } = kontra;
 
 load(
   &#39;assets/imgs/character.png&#39;,
@@ -432,9 +420,8 @@ load(
   // all assets have loaded
 }).catch(function(err) {
   // error loading an asset
-});
-</code></pre></section>
-  <section role="tabpanel" aria-labelledby=load-es-tab data-tabpanel="es"><pre><code class="lang-js">import { load } from 'path/to/kontra.mjs';
+});</code></pre></section>
+  <section role="tabpanel" aria-labelledby=load-es-tab data-tabpanel="es"><pre><code class="language-js">import { load } from 'path/to/kontra.mjs';
 
 load(
   &#39;assets/imgs/character.png&#39;,
@@ -444,9 +431,8 @@ load(
   // all assets have loaded
 }).catch(function(err) {
   // error loading an asset
-});
-</code></pre></section>
-  <section role="tabpanel" aria-labelledby=load-bundle-tab data-tabpanel="bundle"><pre><code class="lang-js">import { load } from &#39;kontra&#39;;
+});</code></pre></section>
+  <section role="tabpanel" aria-labelledby=load-bundle-tab data-tabpanel="bundle"><pre><code class="language-js">import { load } from &#39;kontra&#39;;
 
 load(
   &#39;assets/imgs/character.png&#39;,
@@ -456,8 +442,7 @@ load(
   // all assets have loaded
 }).catch(function(err) {
   // error loading an asset
-});
-</code></pre></section>
+});</code></pre></section>
 </div>
           <h3 id="title-load"><span class="visually-hidden">load</span> Parameters</span></h3>
           <dl aria-labelledby="title-load">
@@ -496,7 +481,7 @@ load(
     </li>
     <li role="presentation"></li>
   </ul>
-  <section role="tabpanel" aria-labelledby=loadaudio-global-tab data-tabpanel="global"><pre><code class="lang-js">let { loadAudio, audioAssets } = kontra;
+  <section role="tabpanel" aria-labelledby=loadaudio-global-tab data-tabpanel="global"><pre><code class="language-js">let { loadAudio, audioAssets } = kontra;
 
 loadAudio([
   &#39;/audio/music.mp3&#39;,
@@ -505,9 +490,8 @@ loadAudio([
 
   // access audio by its name only (not by its .mp3 or .ogg path)
   audioAssets[&#39;/audio/music&#39;].play();
-})
-</code></pre></section>
-  <section role="tabpanel" aria-labelledby=loadaudio-es-tab data-tabpanel="es"><pre><code class="lang-js">import { loadAudio, audioAssets } from 'path/to/kontra.mjs';
+})</code></pre></section>
+  <section role="tabpanel" aria-labelledby=loadaudio-es-tab data-tabpanel="es"><pre><code class="language-js">import { loadAudio, audioAssets } from 'path/to/kontra.mjs';
 
 loadAudio([
   &#39;/audio/music.mp3&#39;,
@@ -516,9 +500,8 @@ loadAudio([
 
   // access audio by its name only (not by its .mp3 or .ogg path)
   audioAssets[&#39;/audio/music&#39;].play();
-})
-</code></pre></section>
-  <section role="tabpanel" aria-labelledby=loadaudio-bundle-tab data-tabpanel="bundle"><pre><code class="lang-js">import { loadAudio, audioAssets } from &#39;kontra&#39;;
+})</code></pre></section>
+  <section role="tabpanel" aria-labelledby=loadaudio-bundle-tab data-tabpanel="bundle"><pre><code class="language-js">import { loadAudio, audioAssets } from &#39;kontra&#39;;
 
 loadAudio([
   &#39;/audio/music.mp3&#39;,
@@ -527,8 +510,7 @@ loadAudio([
 
   // access audio by its name only (not by its .mp3 or .ogg path)
   audioAssets[&#39;/audio/music&#39;].play();
-})
-</code></pre></section>
+})</code></pre></section>
 </div>
           <h3 id="title-loadAudio"><span class="visually-hidden">loadAudio</span> Parameters</span></h3>
           <dl aria-labelledby="title-loadAudio">
@@ -567,24 +549,21 @@ loadAudio([
     </li>
     <li role="presentation"></li>
   </ul>
-  <section role="tabpanel" aria-labelledby=loaddata-global-tab data-tabpanel="global"><pre><code class="lang-js">let { loadData } = kontra;
+  <section role="tabpanel" aria-labelledby=loaddata-global-tab data-tabpanel="global"><pre><code class="language-js">let { loadData } = kontra;
 
 loadData(&#39;assets/data/tile_engine_basic.json&#39;).then(function(data) {
   // data contains the parsed JSON data
-})
-</code></pre></section>
-  <section role="tabpanel" aria-labelledby=loaddata-es-tab data-tabpanel="es"><pre><code class="lang-js">import { loadData } from 'path/to/kontra.mjs';
+})</code></pre></section>
+  <section role="tabpanel" aria-labelledby=loaddata-es-tab data-tabpanel="es"><pre><code class="language-js">import { loadData } from 'path/to/kontra.mjs';
 
 loadData(&#39;assets/data/tile_engine_basic.json&#39;).then(function(data) {
   // data contains the parsed JSON data
-})
-</code></pre></section>
-  <section role="tabpanel" aria-labelledby=loaddata-bundle-tab data-tabpanel="bundle"><pre><code class="lang-js">import { loadData } from &#39;kontra&#39;;
+})</code></pre></section>
+  <section role="tabpanel" aria-labelledby=loaddata-bundle-tab data-tabpanel="bundle"><pre><code class="language-js">import { loadData } from &#39;kontra&#39;;
 
 loadData(&#39;assets/data/tile_engine_basic.json&#39;).then(function(data) {
   // data contains the parsed JSON data
-})
-</code></pre></section>
+})</code></pre></section>
 </div>
           <h3 id="title-loadData"><span class="visually-hidden">loadData</span> Parameters</span></h3>
           <dl aria-labelledby="title-loadData">
@@ -623,24 +602,21 @@ loadData(&#39;assets/data/tile_engine_basic.json&#39;).then(function(data) {
     </li>
     <li role="presentation"></li>
   </ul>
-  <section role="tabpanel" aria-labelledby=loadimage-global-tab data-tabpanel="global"><pre><code class="lang-js">let { loadImage } = kontra;
+  <section role="tabpanel" aria-labelledby=loadimage-global-tab data-tabpanel="global"><pre><code class="language-js">let { loadImage } = kontra;
 
 loadImage(&#39;car.png&#39;).then(function(image) {
   console.log(image.src);  //=&gt; &#39;car.png&#39;
-})
-</code></pre></section>
-  <section role="tabpanel" aria-labelledby=loadimage-es-tab data-tabpanel="es"><pre><code class="lang-js">import { loadImage } from 'path/to/kontra.mjs';
+})</code></pre></section>
+  <section role="tabpanel" aria-labelledby=loadimage-es-tab data-tabpanel="es"><pre><code class="language-js">import { loadImage } from 'path/to/kontra.mjs';
 
 loadImage(&#39;car.png&#39;).then(function(image) {
   console.log(image.src);  //=&gt; &#39;car.png&#39;
-})
-</code></pre></section>
-  <section role="tabpanel" aria-labelledby=loadimage-bundle-tab data-tabpanel="bundle"><pre><code class="lang-js">import { loadImage } from &#39;kontra&#39;;
+})</code></pre></section>
+  <section role="tabpanel" aria-labelledby=loadimage-bundle-tab data-tabpanel="bundle"><pre><code class="language-js">import { loadImage } from &#39;kontra&#39;;
 
 loadImage(&#39;car.png&#39;).then(function(image) {
   console.log(image.src);  //=&gt; &#39;car.png&#39;
-})
-</code></pre></section>
+})</code></pre></section>
 </div>
           <h3 id="title-loadImage"><span class="visually-hidden">loadImage</span> Parameters</span></h3>
           <dl aria-labelledby="title-loadImage">
@@ -678,21 +654,18 @@ loadImage(&#39;car.png&#39;).then(function(image) {
     </li>
     <li role="presentation"></li>
   </ul>
-  <section role="tabpanel" aria-labelledby=setaudiopath-global-tab data-tabpanel="global"><pre><code class="lang-js">let { setAudioPath, load } = kontra;
+  <section role="tabpanel" aria-labelledby=setaudiopath-global-tab data-tabpanel="global"><pre><code class="language-js">let { setAudioPath, load } = kontra;
 
 setAudioPath(&#39;/audio&#39;);
-load(&#39;music.ogg&#39;);  // loads &#39;/audio/music.ogg&#39;
-</code></pre></section>
-  <section role="tabpanel" aria-labelledby=setaudiopath-es-tab data-tabpanel="es"><pre><code class="lang-js">import { setAudioPath, load } from 'path/to/kontra.mjs';
+load(&#39;music.ogg&#39;);  // loads &#39;/audio/music.ogg&#39;</code></pre></section>
+  <section role="tabpanel" aria-labelledby=setaudiopath-es-tab data-tabpanel="es"><pre><code class="language-js">import { setAudioPath, load } from 'path/to/kontra.mjs';
 
 setAudioPath(&#39;/audio&#39;);
-load(&#39;music.ogg&#39;);  // loads &#39;/audio/music.ogg&#39;
-</code></pre></section>
-  <section role="tabpanel" aria-labelledby=setaudiopath-bundle-tab data-tabpanel="bundle"><pre><code class="lang-js">import { setAudioPath, load } from &#39;kontra&#39;;
+load(&#39;music.ogg&#39;);  // loads &#39;/audio/music.ogg&#39;</code></pre></section>
+  <section role="tabpanel" aria-labelledby=setaudiopath-bundle-tab data-tabpanel="bundle"><pre><code class="language-js">import { setAudioPath, load } from &#39;kontra&#39;;
 
 setAudioPath(&#39;/audio&#39;);
-load(&#39;music.ogg&#39;);  // loads &#39;/audio/music.ogg&#39;
-</code></pre></section>
+load(&#39;music.ogg&#39;);  // loads &#39;/audio/music.ogg&#39;</code></pre></section>
 </div>
           <h3 id="title-setAudioPath"><span class="visually-hidden">setAudioPath</span> Parameters</span></h3>
           <dl aria-labelledby="title-setAudioPath">
@@ -727,21 +700,18 @@ load(&#39;music.ogg&#39;);  // loads &#39;/audio/music.ogg&#39;
     </li>
     <li role="presentation"></li>
   </ul>
-  <section role="tabpanel" aria-labelledby=setdatapath-global-tab data-tabpanel="global"><pre><code class="lang-js">let { setDataPath, load } = kontra;
+  <section role="tabpanel" aria-labelledby=setdatapath-global-tab data-tabpanel="global"><pre><code class="language-js">let { setDataPath, load } = kontra;
 
 setDataPath(&#39;/data&#39;);
-load(&#39;file.json&#39;);  // loads &#39;/data/file.json&#39;
-</code></pre></section>
-  <section role="tabpanel" aria-labelledby=setdatapath-es-tab data-tabpanel="es"><pre><code class="lang-js">import { setDataPath, load } from 'path/to/kontra.mjs';
+load(&#39;file.json&#39;);  // loads &#39;/data/file.json&#39;</code></pre></section>
+  <section role="tabpanel" aria-labelledby=setdatapath-es-tab data-tabpanel="es"><pre><code class="language-js">import { setDataPath, load } from 'path/to/kontra.mjs';
 
 setDataPath(&#39;/data&#39;);
-load(&#39;file.json&#39;);  // loads &#39;/data/file.json&#39;
-</code></pre></section>
-  <section role="tabpanel" aria-labelledby=setdatapath-bundle-tab data-tabpanel="bundle"><pre><code class="lang-js">import { setDataPath, load } from &#39;kontra&#39;;
+load(&#39;file.json&#39;);  // loads &#39;/data/file.json&#39;</code></pre></section>
+  <section role="tabpanel" aria-labelledby=setdatapath-bundle-tab data-tabpanel="bundle"><pre><code class="language-js">import { setDataPath, load } from &#39;kontra&#39;;
 
 setDataPath(&#39;/data&#39;);
-load(&#39;file.json&#39;);  // loads &#39;/data/file.json&#39;
-</code></pre></section>
+load(&#39;file.json&#39;);  // loads &#39;/data/file.json&#39;</code></pre></section>
 </div>
           <h3 id="title-setDataPath"><span class="visually-hidden">setDataPath</span> Parameters</span></h3>
           <dl aria-labelledby="title-setDataPath">
@@ -776,21 +746,18 @@ load(&#39;file.json&#39;);  // loads &#39;/data/file.json&#39;
     </li>
     <li role="presentation"></li>
   </ul>
-  <section role="tabpanel" aria-labelledby=setimagepath-global-tab data-tabpanel="global"><pre><code class="lang-js">let { setImagePath, load } = kontra;
+  <section role="tabpanel" aria-labelledby=setimagepath-global-tab data-tabpanel="global"><pre><code class="language-js">let { setImagePath, load } = kontra;
 
 setImagePath(&#39;/imgs&#39;);
-load(&#39;character.png&#39;);  // loads &#39;/imgs/character.png&#39;
-</code></pre></section>
-  <section role="tabpanel" aria-labelledby=setimagepath-es-tab data-tabpanel="es"><pre><code class="lang-js">import { setImagePath, load } from 'path/to/kontra.mjs';
+load(&#39;character.png&#39;);  // loads &#39;/imgs/character.png&#39;</code></pre></section>
+  <section role="tabpanel" aria-labelledby=setimagepath-es-tab data-tabpanel="es"><pre><code class="language-js">import { setImagePath, load } from 'path/to/kontra.mjs';
 
 setImagePath(&#39;/imgs&#39;);
-load(&#39;character.png&#39;);  // loads &#39;/imgs/character.png&#39;
-</code></pre></section>
-  <section role="tabpanel" aria-labelledby=setimagepath-bundle-tab data-tabpanel="bundle"><pre><code class="lang-js">import { setImagePath, load } from &#39;kontra&#39;;
+load(&#39;character.png&#39;);  // loads &#39;/imgs/character.png&#39;</code></pre></section>
+  <section role="tabpanel" aria-labelledby=setimagepath-bundle-tab data-tabpanel="bundle"><pre><code class="language-js">import { setImagePath, load } from &#39;kontra&#39;;
 
 setImagePath(&#39;/imgs&#39;);
-load(&#39;character.png&#39;);  // loads &#39;/imgs/character.png&#39;
-</code></pre></section>
+load(&#39;character.png&#39;);  // loads &#39;/imgs/character.png&#39;</code></pre></section>
 </div>
           <h3 id="title-setImagePath"><span class="visually-hidden">setImagePath</span> Parameters</span></h3>
           <dl aria-labelledby="title-setImagePath">

--- a/docs/api/core.html
+++ b/docs/api/core.html
@@ -82,30 +82,27 @@ objects.</p>
     </li>
     <li role="presentation"></li>
   </ul>
-  <section role="tabpanel" aria-labelledby=core-global-tab data-tabpanel="global"><pre><code class="lang-js">let { getCanvas, getContext, init } = kontra;
+  <section role="tabpanel" aria-labelledby=core-global-tab data-tabpanel="global"><pre><code class="language-js">let { getCanvas, getContext, init } = kontra;
 
 let { canvas, context } = init();
 
 // or can get canvas and context through functions
 canvas = getCanvas();
-context = getContext();
-</code></pre></section>
-  <section role="tabpanel" aria-labelledby=core-es-tab data-tabpanel="es"><pre><code class="lang-js">import { getCanvas, getContext, init } from 'path/to/kontra.mjs';
+context = getContext();</code></pre></section>
+  <section role="tabpanel" aria-labelledby=core-es-tab data-tabpanel="es"><pre><code class="language-js">import { getCanvas, getContext, init } from 'path/to/kontra.mjs';
 
 let { canvas, context } = init();
 
 // or can get canvas and context through functions
 canvas = getCanvas();
-context = getContext();
-</code></pre></section>
-  <section role="tabpanel" aria-labelledby=core-bundle-tab data-tabpanel="bundle"><pre><code class="lang-js">import { getCanvas, getContext, init } from &#39;kontra&#39;;
+context = getContext();</code></pre></section>
+  <section role="tabpanel" aria-labelledby=core-bundle-tab data-tabpanel="bundle"><pre><code class="language-js">import { getCanvas, getContext, init } from &#39;kontra&#39;;
 
 let { canvas, context } = init();
 
 // or can get canvas and context through functions
 canvas = getCanvas();
-context = getContext();
-</code></pre></section>
+context = getContext();</code></pre></section>
 </div>
         
 
@@ -189,18 +186,15 @@ context = getContext();
     </li>
     <li role="presentation"></li>
   </ul>
-  <section role="tabpanel" aria-labelledby=init-global-tab data-tabpanel="global"><pre><code class="lang-js">let { init } = kontra;
+  <section role="tabpanel" aria-labelledby=init-global-tab data-tabpanel="global"><pre><code class="language-js">let { init } = kontra;
 
-let { canvas, context } = init(&#39;game&#39;);
-</code></pre></section>
-  <section role="tabpanel" aria-labelledby=init-es-tab data-tabpanel="es"><pre><code class="lang-js">import { init } from 'path/to/kontra.mjs';
+let { canvas, context } = init(&#39;game&#39;);</code></pre></section>
+  <section role="tabpanel" aria-labelledby=init-es-tab data-tabpanel="es"><pre><code class="language-js">import { init } from 'path/to/kontra.mjs';
 
-let { canvas, context } = init(&#39;game&#39;);
-</code></pre></section>
-  <section role="tabpanel" aria-labelledby=init-bundle-tab data-tabpanel="bundle"><pre><code class="lang-js">import { init } from &#39;kontra&#39;;
+let { canvas, context } = init(&#39;game&#39;);</code></pre></section>
+  <section role="tabpanel" aria-labelledby=init-bundle-tab data-tabpanel="bundle"><pre><code class="language-js">import { init } from &#39;kontra&#39;;
 
-let { canvas, context } = init(&#39;game&#39;);
-</code></pre></section>
+let { canvas, context } = init(&#39;game&#39;);</code></pre></section>
 </div>
           <h3 id="title-init"><span class="visually-hidden">init</span> Parameters</span></h3>
           <dl aria-labelledby="title-init">

--- a/docs/api/events.html
+++ b/docs/api/events.html
@@ -81,7 +81,7 @@
     </li>
     <li role="presentation"></li>
   </ul>
-  <section role="tabpanel" aria-labelledby=events-global-tab data-tabpanel="global"><pre><code class="lang-js">let { on, off, emit } = kontra;
+  <section role="tabpanel" aria-labelledby=events-global-tab data-tabpanel="global"><pre><code class="language-js">let { on, off, emit } = kontra;
 
 function callback(a, b, c) {
   console.log({a, b, c});
@@ -89,9 +89,8 @@ function callback(a, b, c) {
 
 on(&#39;myEvent&#39;, callback);
 emit(&#39;myEvent&#39;, 1, 2, 3);  //=&gt; {a: 1, b: 2, c: 3}
-off(&#39;myEvent&#39;, callback);
-</code></pre></section>
-  <section role="tabpanel" aria-labelledby=events-es-tab data-tabpanel="es"><pre><code class="lang-js">import { on, off, emit } from 'path/to/kontra.mjs';
+off(&#39;myEvent&#39;, callback);</code></pre></section>
+  <section role="tabpanel" aria-labelledby=events-es-tab data-tabpanel="es"><pre><code class="language-js">import { on, off, emit } from 'path/to/kontra.mjs';
 
 function callback(a, b, c) {
   console.log({a, b, c});
@@ -99,9 +98,8 @@ function callback(a, b, c) {
 
 on(&#39;myEvent&#39;, callback);
 emit(&#39;myEvent&#39;, 1, 2, 3);  //=&gt; {a: 1, b: 2, c: 3}
-off(&#39;myEvent&#39;, callback);
-</code></pre></section>
-  <section role="tabpanel" aria-labelledby=events-bundle-tab data-tabpanel="bundle"><pre><code class="lang-js">import { on, off, emit } from &#39;kontra&#39;;
+off(&#39;myEvent&#39;, callback);</code></pre></section>
+  <section role="tabpanel" aria-labelledby=events-bundle-tab data-tabpanel="bundle"><pre><code class="language-js">import { on, off, emit } from &#39;kontra&#39;;
 
 function callback(a, b, c) {
   console.log({a, b, c});
@@ -109,8 +107,7 @@ function callback(a, b, c) {
 
 on(&#39;myEvent&#39;, callback);
 emit(&#39;myEvent&#39;, 1, 2, 3);  //=&gt; {a: 1, b: 2, c: 3}
-off(&#39;myEvent&#39;, callback);
-</code></pre></section>
+off(&#39;myEvent&#39;, callback);</code></pre></section>
 </div>
         
 

--- a/docs/api/gameLoop.html
+++ b/docs/api/gameLoop.html
@@ -84,7 +84,7 @@
     </li>
     <li role="presentation"></li>
   </ul>
-  <section role="tabpanel" aria-labelledby=gameloop-global-tab data-tabpanel="global"><pre><code class="lang-js">let { Sprite, GameLoop } = kontra;
+  <section role="tabpanel" aria-labelledby=gameloop-global-tab data-tabpanel="global"><pre><code class="language-js">let { Sprite, GameLoop } = kontra;
 
 let sprite = Sprite({
   x: 100,
@@ -109,9 +109,8 @@ let loop = GameLoop({
   }
 });
 
-loop.start();
-</code></pre></section>
-  <section role="tabpanel" aria-labelledby=gameloop-es-tab data-tabpanel="es"><pre><code class="lang-js">import { Sprite, GameLoop } from 'path/to/kontra.mjs';
+loop.start();</code></pre></section>
+  <section role="tabpanel" aria-labelledby=gameloop-es-tab data-tabpanel="es"><pre><code class="language-js">import { Sprite, GameLoop } from 'path/to/kontra.mjs';
 
 let sprite = Sprite({
   x: 100,
@@ -136,9 +135,8 @@ let loop = GameLoop({
   }
 });
 
-loop.start();
-</code></pre></section>
-  <section role="tabpanel" aria-labelledby=gameloop-bundle-tab data-tabpanel="bundle"><pre><code class="lang-js">import { Sprite, GameLoop } from &#39;kontra&#39;;
+loop.start();</code></pre></section>
+  <section role="tabpanel" aria-labelledby=gameloop-bundle-tab data-tabpanel="bundle"><pre><code class="language-js">import { Sprite, GameLoop } from &#39;kontra&#39;;
 
 let sprite = Sprite({
   x: 100,
@@ -163,8 +161,7 @@ let loop = GameLoop({
   }
 });
 
-loop.start();
-</code></pre></section>
+loop.start();</code></pre></section>
 </div>
         <h3 id="title-GameLoop"><span class="visually-hidden">GameLoop</span> Parameters</span></h3>
         <dl aria-labelledby="title-GameLoop">
@@ -268,7 +265,7 @@ loop.start();
     </li>
     <li role="presentation"></li>
   </ul>
-  <section role="tabpanel" aria-labelledby=isstopped-global-tab data-tabpanel="global"><pre><code class="lang-js">let { GameLoop } = kontra;
+  <section role="tabpanel" aria-labelledby=isstopped-global-tab data-tabpanel="global"><pre><code class="language-js">let { GameLoop } = kontra;
 
 let loop = GameLoop({
   // ...
@@ -279,9 +276,8 @@ loop.start();
 console.log(loop.isStopped);  //=&gt; false
 
 loop.stop();
-console.log(loop.isStopped);  //=&gt; true
-</code></pre></section>
-  <section role="tabpanel" aria-labelledby=isstopped-es-tab data-tabpanel="es"><pre><code class="lang-js">import { GameLoop } from 'path/to/kontra.mjs';
+console.log(loop.isStopped);  //=&gt; true</code></pre></section>
+  <section role="tabpanel" aria-labelledby=isstopped-es-tab data-tabpanel="es"><pre><code class="language-js">import { GameLoop } from 'path/to/kontra.mjs';
 
 let loop = GameLoop({
   // ...
@@ -292,9 +288,8 @@ loop.start();
 console.log(loop.isStopped);  //=&gt; false
 
 loop.stop();
-console.log(loop.isStopped);  //=&gt; true
-</code></pre></section>
-  <section role="tabpanel" aria-labelledby=isstopped-bundle-tab data-tabpanel="bundle"><pre><code class="lang-js">import { GameLoop } from &#39;kontra&#39;;
+console.log(loop.isStopped);  //=&gt; true</code></pre></section>
+  <section role="tabpanel" aria-labelledby=isstopped-bundle-tab data-tabpanel="bundle"><pre><code class="language-js">import { GameLoop } from &#39;kontra&#39;;
 
 let loop = GameLoop({
   // ...
@@ -305,8 +300,7 @@ loop.start();
 console.log(loop.isStopped);  //=&gt; false
 
 loop.stop();
-console.log(loop.isStopped);  //=&gt; true
-</code></pre></section>
+console.log(loop.isStopped);  //=&gt; true</code></pre></section>
 </div>
           
         </section>

--- a/docs/api/keyboard.html
+++ b/docs/api/keyboard.html
@@ -81,7 +81,7 @@
     </li>
     <li role="presentation"></li>
   </ul>
-  <section role="tabpanel" aria-labelledby=keyboard-global-tab data-tabpanel="global"><pre><code class="lang-js">let { initKeys, keyPressed } = kontra;
+  <section role="tabpanel" aria-labelledby=keyboard-global-tab data-tabpanel="global"><pre><code class="language-js">let { initKeys, keyPressed } = kontra;
 
 // this function must be called first before keyboard
 // functions will work
@@ -91,9 +91,8 @@ function update() {
   if (keyPressed(&#39;left&#39;)) {
     // move left
   }
-}
-</code></pre></section>
-  <section role="tabpanel" aria-labelledby=keyboard-es-tab data-tabpanel="es"><pre><code class="lang-js">import { initKeys, keyPressed } from 'path/to/kontra.mjs';
+}</code></pre></section>
+  <section role="tabpanel" aria-labelledby=keyboard-es-tab data-tabpanel="es"><pre><code class="language-js">import { initKeys, keyPressed } from 'path/to/kontra.mjs';
 
 // this function must be called first before keyboard
 // functions will work
@@ -103,9 +102,8 @@ function update() {
   if (keyPressed(&#39;left&#39;)) {
     // move left
   }
-}
-</code></pre></section>
-  <section role="tabpanel" aria-labelledby=keyboard-bundle-tab data-tabpanel="bundle"><pre><code class="lang-js">import { initKeys, keyPressed } from &#39;kontra&#39;;
+}</code></pre></section>
+  <section role="tabpanel" aria-labelledby=keyboard-bundle-tab data-tabpanel="bundle"><pre><code class="language-js">import { initKeys, keyPressed } from &#39;kontra&#39;;
 
 // this function must be called first before keyboard
 // functions will work
@@ -115,8 +113,7 @@ function update() {
   if (keyPressed(&#39;left&#39;)) {
     // move left
   }
-}
-</code></pre></section>
+}</code></pre></section>
 </div>
         
 
@@ -207,7 +204,7 @@ function update() {
     </li>
     <li role="presentation"></li>
   </ul>
-  <section role="tabpanel" aria-labelledby=bindkeys-global-tab data-tabpanel="global"><pre><code class="lang-js">let { initKeys, bindKeys } = kontra;
+  <section role="tabpanel" aria-labelledby=bindkeys-global-tab data-tabpanel="global"><pre><code class="language-js">let { initKeys, bindKeys } = kontra;
 
 initKeys();
 
@@ -217,9 +214,8 @@ bindKeys(&#39;p&#39;, function(e) {
 bindKeys([&#39;enter&#39;, &#39;space&#39;], function(e) {
   e.preventDefault();
   // fire gun
-});
-</code></pre></section>
-  <section role="tabpanel" aria-labelledby=bindkeys-es-tab data-tabpanel="es"><pre><code class="lang-js">import { initKeys, bindKeys } from 'path/to/kontra.mjs';
+});</code></pre></section>
+  <section role="tabpanel" aria-labelledby=bindkeys-es-tab data-tabpanel="es"><pre><code class="language-js">import { initKeys, bindKeys } from 'path/to/kontra.mjs';
 
 initKeys();
 
@@ -229,9 +225,8 @@ bindKeys(&#39;p&#39;, function(e) {
 bindKeys([&#39;enter&#39;, &#39;space&#39;], function(e) {
   e.preventDefault();
   // fire gun
-});
-</code></pre></section>
-  <section role="tabpanel" aria-labelledby=bindkeys-bundle-tab data-tabpanel="bundle"><pre><code class="lang-js">import { initKeys, bindKeys } from &#39;kontra&#39;;
+});</code></pre></section>
+  <section role="tabpanel" aria-labelledby=bindkeys-bundle-tab data-tabpanel="bundle"><pre><code class="language-js">import { initKeys, bindKeys } from &#39;kontra&#39;;
 
 initKeys();
 
@@ -241,8 +236,7 @@ bindKeys(&#39;p&#39;, function(e) {
 bindKeys([&#39;enter&#39;, &#39;space&#39;], function(e) {
   e.preventDefault();
   // fire gun
-});
-</code></pre></section>
+});</code></pre></section>
 </div>
           <h3 id="title-bindKeys"><span class="visually-hidden">bindKeys</span> Parameters</span></h3>
           <dl aria-labelledby="title-bindKeys">
@@ -288,30 +282,27 @@ bindKeys([&#39;enter&#39;, &#39;space&#39;], function(e) {
     </li>
     <li role="presentation"></li>
   </ul>
-  <section role="tabpanel" aria-labelledby=keymap-global-tab data-tabpanel="global"><pre><code class="lang-js">let { keyMap, bindKeys } = kontra;
+  <section role="tabpanel" aria-labelledby=keymap-global-tab data-tabpanel="global"><pre><code class="language-js">let { keyMap, bindKeys } = kontra;
 
 keyMap[34] = &#39;pageDown&#39;;
 
 bindKeys(&#39;pageDown&#39;, function(e) {
   // handle pageDown key
-});
-</code></pre></section>
-  <section role="tabpanel" aria-labelledby=keymap-es-tab data-tabpanel="es"><pre><code class="lang-js">import { keyMap, bindKeys } from 'path/to/kontra.mjs';
+});</code></pre></section>
+  <section role="tabpanel" aria-labelledby=keymap-es-tab data-tabpanel="es"><pre><code class="language-js">import { keyMap, bindKeys } from 'path/to/kontra.mjs';
 
 keyMap[34] = &#39;pageDown&#39;;
 
 bindKeys(&#39;pageDown&#39;, function(e) {
   // handle pageDown key
-});
-</code></pre></section>
-  <section role="tabpanel" aria-labelledby=keymap-bundle-tab data-tabpanel="bundle"><pre><code class="lang-js">import { keyMap, bindKeys } from &#39;kontra&#39;;
+});</code></pre></section>
+  <section role="tabpanel" aria-labelledby=keymap-bundle-tab data-tabpanel="bundle"><pre><code class="language-js">import { keyMap, bindKeys } from &#39;kontra&#39;;
 
 keyMap[34] = &#39;pageDown&#39;;
 
 bindKeys(&#39;pageDown&#39;, function(e) {
   // handle pageDown key
-});
-</code></pre></section>
+});</code></pre></section>
 </div>
           
         </section>
@@ -337,7 +328,7 @@ bindKeys(&#39;pageDown&#39;, function(e) {
     </li>
     <li role="presentation"></li>
   </ul>
-  <section role="tabpanel" aria-labelledby=keypressed-global-tab data-tabpanel="global"><pre><code class="lang-js">let { Sprite, initKeys, keyPressed } = kontra;
+  <section role="tabpanel" aria-labelledby=keypressed-global-tab data-tabpanel="global"><pre><code class="language-js">let { Sprite, initKeys, keyPressed } = kontra;
 
 initKeys();
 
@@ -357,9 +348,8 @@ let sprite = Sprite({
       // down arrow pressed
     }
   }
-});
-</code></pre></section>
-  <section role="tabpanel" aria-labelledby=keypressed-es-tab data-tabpanel="es"><pre><code class="lang-js">import { Sprite, initKeys, keyPressed } from 'path/to/kontra.mjs';
+});</code></pre></section>
+  <section role="tabpanel" aria-labelledby=keypressed-es-tab data-tabpanel="es"><pre><code class="language-js">import { Sprite, initKeys, keyPressed } from 'path/to/kontra.mjs';
 
 initKeys();
 
@@ -379,9 +369,8 @@ let sprite = Sprite({
       // down arrow pressed
     }
   }
-});
-</code></pre></section>
-  <section role="tabpanel" aria-labelledby=keypressed-bundle-tab data-tabpanel="bundle"><pre><code class="lang-js">import { Sprite, initKeys, keyPressed } from &#39;kontra&#39;;
+});</code></pre></section>
+  <section role="tabpanel" aria-labelledby=keypressed-bundle-tab data-tabpanel="bundle"><pre><code class="language-js">import { Sprite, initKeys, keyPressed } from &#39;kontra&#39;;
 
 initKeys();
 
@@ -401,8 +390,7 @@ let sprite = Sprite({
       // down arrow pressed
     }
   }
-});
-</code></pre></section>
+});</code></pre></section>
 </div>
           <h3 id="title-keyPressed"><span class="visually-hidden">keyPressed</span> Parameters</span></h3>
           <dl aria-labelledby="title-keyPressed">
@@ -440,21 +428,18 @@ let sprite = Sprite({
     </li>
     <li role="presentation"></li>
   </ul>
-  <section role="tabpanel" aria-labelledby=unbindkeys-global-tab data-tabpanel="global"><pre><code class="lang-js">let { unbindKeys } = kontra;
+  <section role="tabpanel" aria-labelledby=unbindkeys-global-tab data-tabpanel="global"><pre><code class="language-js">let { unbindKeys } = kontra;
 
 unbindKeys(&#39;left&#39;);
-unbindKeys([&#39;enter&#39;, &#39;space&#39;]);
-</code></pre></section>
-  <section role="tabpanel" aria-labelledby=unbindkeys-es-tab data-tabpanel="es"><pre><code class="lang-js">import { unbindKeys } from 'path/to/kontra.mjs';
+unbindKeys([&#39;enter&#39;, &#39;space&#39;]);</code></pre></section>
+  <section role="tabpanel" aria-labelledby=unbindkeys-es-tab data-tabpanel="es"><pre><code class="language-js">import { unbindKeys } from 'path/to/kontra.mjs';
 
 unbindKeys(&#39;left&#39;);
-unbindKeys([&#39;enter&#39;, &#39;space&#39;]);
-</code></pre></section>
-  <section role="tabpanel" aria-labelledby=unbindkeys-bundle-tab data-tabpanel="bundle"><pre><code class="lang-js">import { unbindKeys } from &#39;kontra&#39;;
+unbindKeys([&#39;enter&#39;, &#39;space&#39;]);</code></pre></section>
+  <section role="tabpanel" aria-labelledby=unbindkeys-bundle-tab data-tabpanel="bundle"><pre><code class="language-js">import { unbindKeys } from &#39;kontra&#39;;
 
 unbindKeys(&#39;left&#39;);
-unbindKeys([&#39;enter&#39;, &#39;space&#39;]);
-</code></pre></section>
+unbindKeys([&#39;enter&#39;, &#39;space&#39;]);</code></pre></section>
 </div>
           <h3 id="title-unbindKeys"><span class="visually-hidden">unbindKeys</span> Parameters</span></h3>
           <dl aria-labelledby="title-unbindKeys">

--- a/docs/api/plugin.html
+++ b/docs/api/plugin.html
@@ -103,6 +103,13 @@ registerPlugin(Sprite, loggingPlugin);</code></pre></section>
           <h2 id="toc"><a href="#toc" class="section-link">Table of Contents<span aria-hidden="true">#</span></a></h2>
 
           <ul aria-labelledby="toc">
+            <li>
+              <ul>
+                <li><a href="api/plugin#how-to create a plugin">How to Create a Plugin</a></li>
+                <li><a href="api/plugin#before-intercept functions">Before Intercept Functions</a></li>
+                <li><a href="api/plugin#after-intercept functions">After Intercept Functions</a></li>
+              </ul>
+            </li>
 
 
             <li>
@@ -128,6 +135,206 @@ registerPlugin(Sprite, loggingPlugin);</code></pre></section>
           </ul>
         </section>
 
+        <section>
+          <h2 id="how-to create a plugin">
+            <a href="#how-to create a plugin" class="section-link">
+              <span>How to Create a Plugin</span>
+              <span aria-hidden="true">#</span>
+            </a>
+          </h2>
+
+          <p>A plugin is an object that defines a set of intercept functions that should be run before or after a Kontra objects functions. These functions allow you to modify the code or change the behavior of the intercepted functions.</p>
+<p>An intercept function is named the same name as the function it will intercept. The function name is also prefixed with <code>before</code> to have the function run before the intercepted function, or <code>after</code> to run after the intercepted function.</p>
+<p>For example, if you wish to add a function to run after a Sprites <code>collidesWidth()</code> function, the name of the intercept function would be <code>afterCollidesWidth</code> (note the capitalization of the <code>collidesWidth</code> function name). <code>beforeCollidesWidth</code> would run before the Sprites <code>collidesWidth()</code> function.</p>
+<p>A plugin can define any number of before and after intercept functions. When the plugin is registered for a Kontra object, only intercept functions that match a function name in the Kontra object will be intercepted.</p>
+<p>As the plugin author, you should not <a href="#registerPlugin">register</a> the plugin yourself. You should only export the plugin object and let the consumer register it.</p>
+<pre><code class="language-js">// pluginCode.js
+const loggingPlugin = {
+  afterCollidesWith(sprite, result, object) {
+    console.log(&#39;collision between sprites!&#39;);
+  }
+};
+export default loggingPlugin;</code></pre>
+<div class="tablist">
+  <ul role="tablist">
+    <li role="presentation" data-tab="global">
+      <button role="tab" id="how-to-create-a-plugin-global-tab">Global Object</button>
+    </li>
+    <li role="presentation" data-tab="es">
+      <button role="tab" id="how-to-create-a-plugin-es-tab">ES Module Import</button>
+    </li>
+    <li role="presentation" data-tab="bundle">
+      <button role="tab" id="how-to-create-a-plugin-bundle-tab">Module Bundler</button>
+    </li>
+    <li role="presentation"></li>
+  </ul>
+  <section role="tabpanel" aria-labelledby=how-to-create-a-plugin-global-tab data-tabpanel="global"><pre><code class="language-js">// consumerCode.js
+let { registerPlugin, Sprite } = kontra;
+import loggingPlugin from pluginCode.js;
+
+// have the plugin run for all Sprites
+registerPlugin(Sprite, loggingPlugin);
+
+let sprite1 = Sprite({
+  x: 10,
+  y: 20,
+  width: 10,
+  height: 10
+});
+
+let sprite2 = Sprite({
+  x: 15,
+  y: 20,
+  width: 10,
+  height: 10
+});
+
+sprite1.collidesWith(sprite2);  //=&gt; &#39;collision between sprites!&#39;; true</code></pre></section>
+  <section role="tabpanel" aria-labelledby=how-to-create-a-plugin-es-tab data-tabpanel="es"><pre><code class="language-js">// consumerCode.js
+import { registerPlugin, Sprite } from 'path/to/kontra.mjs';
+import loggingPlugin from pluginCode.js;
+
+// have the plugin run for all Sprites
+registerPlugin(Sprite, loggingPlugin);
+
+let sprite1 = Sprite({
+  x: 10,
+  y: 20,
+  width: 10,
+  height: 10
+});
+
+let sprite2 = Sprite({
+  x: 15,
+  y: 20,
+  width: 10,
+  height: 10
+});
+
+sprite1.collidesWith(sprite2);  //=&gt; &#39;collision between sprites!&#39;; true</code></pre></section>
+  <section role="tabpanel" aria-labelledby=how-to-create-a-plugin-bundle-tab data-tabpanel="bundle"><pre><code class="language-js">// consumerCode.js
+import { registerPlugin, Sprite } from &#39;kontra&#39;;
+import loggingPlugin from pluginCode.js;
+
+// have the plugin run for all Sprites
+registerPlugin(Sprite, loggingPlugin);
+
+let sprite1 = Sprite({
+  x: 10,
+  y: 20,
+  width: 10,
+  height: 10
+});
+
+let sprite2 = Sprite({
+  x: 15,
+  y: 20,
+  width: 10,
+  height: 10
+});
+
+sprite1.collidesWith(sprite2);  //=&gt; &#39;collision between sprites!&#39;; true</code></pre></section>
+</div>
+        </section>
+        <section>
+          <h2 id="before-intercept functions">
+            <a href="#before-intercept functions" class="section-link">
+              <span>Before Intercept Functions</span>
+              <span aria-hidden="true">#</span>
+            </a>
+          </h2>
+
+          <p>A before intercept function can be used to modify or change the arguments that will be passed to the intercepted function.</p>
+<p>The function will be passed the <code>this</code> context of the intercepted object as well as all arguments of the original call. The function should either return an Array of the arguments if modifying them or return <code>null</code> or nothing if not modifying the arguments.</p>
+<pre><code class="language-js">class MyObj {
+  add(a, b) {
+    return a + b;
+  }
+}
+
+// create a plugin that doubles the arguments before passing
+// them to the original add function
+registerPlugin(MyObj, {
+  beforeAdd(context, a, b) {
+    return [a * 2, b * 2];
+  }
+});
+
+const obj = new MyObj();
+obj.add(1, 2);  //=&gt; 6</code></pre>
+<p>Multiple before intercept functions can be registered for the same function. All functions will be run in the order they were registered. The functions return value will be passed to the next function. If the function doesn&#39;t modify the arguments (returned <code>null</code> or nothing) then the functions parameters will be passed to the next function instead.</p>
+<pre><code class="language-js">class MyObj {
+  add(a, b) {
+    return a + b;
+  }
+}
+
+// log the arguments of the call and pass them unchanged to
+// the next plugin
+registerPlugin(MyObj, {
+  beforeAdd(context, a, b) {
+    console.log(`add passed: ${a}, ${b}`);
+  }
+});
+
+registerPlugin(MyObj, {
+  beforeAdd(context, a, b) {  // receives a=1 and b=2
+    return [a * 2, b * 2];
+  }
+});
+
+const obj = new MyObj();
+obj.add(1, 2);  //=&gt; &#39;add passed: 1, 2&#39;; 6</code></pre>
+        </section>
+        <section>
+          <h2 id="after-intercept functions">
+            <a href="#after-intercept functions" class="section-link">
+              <span>After Intercept Functions</span>
+              <span aria-hidden="true">#</span>
+            </a>
+          </h2>
+
+          <p>An after intercept function can be used to modify or change the results of the intercepted function.</p>
+<p>The function will be passed the <code>this</code> context of the intercepted object, the result of the intercepted function, and the final arguments passed to the intercepted function. The function should either return a value if modifying the result or return <code>null</code> or nothing if not modifying the result.</p>
+<pre><code class="language-js">class MyObj {
+  add(a, b) {
+    return a + b;
+  }
+}
+
+// create a plugin that doubles the result
+registerPlugin(MyObj, {
+  afterAdd(context, result, a, b) {
+    return result * 2;
+  }
+});
+
+const obj = new MyObj();
+obj.add(1, 2);  //=&gt; 6</code></pre>
+<p>Multiple after intercept functions can be registered for the same function. All functions will be run in the order they were registered. Each functions return value will be passed to the next function. If the function doesn&#39;t modify the result (returned <code>null</code> or nothing) then the functions parameters will be passed to the next function instead.</p>
+<pre><code class="language-js">class MyObj {
+  add(a, b) {
+    return a + b;
+  }
+}
+
+// log the arguments of the call and pass them unchanged to
+// the next plugin
+registerPlugin(MyObj, {
+  afterAdd(context, result, a, b) {
+    console.log(`add passed: ${a}, ${b} and returned ${result}`);
+  }
+});
+
+registerPlugin(MyObj, {
+  afterAdd(context, result, a, b) {  // receives result=3
+    return result * 2;
+  }
+});
+
+const obj = new MyObj();
+obj.add(1, 2);  //=&gt; &#39;add passed: 1, 2 and returned 3&#39;; 6</code></pre>
+        </section>
 
         <section>
           <h2 id="extendObject">

--- a/docs/api/plugin.html
+++ b/docs/api/plugin.html
@@ -81,24 +81,21 @@
     </li>
     <li role="presentation"></li>
   </ul>
-  <section role="tabpanel" aria-labelledby=plugin-global-tab data-tabpanel="global"><pre><code class="lang-js">let { registerPlugin, Sprite } = kontra;
+  <section role="tabpanel" aria-labelledby=plugin-global-tab data-tabpanel="global"><pre><code class="language-js">let { registerPlugin, Sprite } = kontra;
 import loggingPlugin from &#39;path/to/plugin/code.js&#39;
 
 // register a plugin that adds logging to all Sprites
-registerPlugin(Sprite, loggingPlugin);
-</code></pre></section>
-  <section role="tabpanel" aria-labelledby=plugin-es-tab data-tabpanel="es"><pre><code class="lang-js">import { registerPlugin, Sprite } from 'path/to/kontra.mjs';
+registerPlugin(Sprite, loggingPlugin);</code></pre></section>
+  <section role="tabpanel" aria-labelledby=plugin-es-tab data-tabpanel="es"><pre><code class="language-js">import { registerPlugin, Sprite } from 'path/to/kontra.mjs';
 import loggingPlugin from &#39;path/to/plugin/code.js&#39;
 
 // register a plugin that adds logging to all Sprites
-registerPlugin(Sprite, loggingPlugin);
-</code></pre></section>
-  <section role="tabpanel" aria-labelledby=plugin-bundle-tab data-tabpanel="bundle"><pre><code class="lang-js">import { registerPlugin, Sprite } from &#39;kontra&#39;;
+registerPlugin(Sprite, loggingPlugin);</code></pre></section>
+  <section role="tabpanel" aria-labelledby=plugin-bundle-tab data-tabpanel="bundle"><pre><code class="language-js">import { registerPlugin, Sprite } from &#39;kontra&#39;;
 import loggingPlugin from &#39;path/to/plugin/code.js&#39;
 
 // register a plugin that adds logging to all Sprites
-registerPlugin(Sprite, loggingPlugin);
-</code></pre></section>
+registerPlugin(Sprite, loggingPlugin);</code></pre></section>
 </div>
         
 
@@ -106,13 +103,6 @@ registerPlugin(Sprite, loggingPlugin);
           <h2 id="toc"><a href="#toc" class="section-link">Table of Contents<span aria-hidden="true">#</span></a></h2>
 
           <ul aria-labelledby="toc">
-            <li>
-              <ul>
-                <li><a href="api/plugin#how-to create a plugin">How to Create a Plugin</a></li>
-                <li><a href="api/plugin#before-intercept functions">Before Intercept Functions</a></li>
-                <li><a href="api/plugin#after-intercept functions">After Intercept Functions</a></li>
-              </ul>
-            </li>
 
 
             <li>
@@ -138,214 +128,6 @@ registerPlugin(Sprite, loggingPlugin);
           </ul>
         </section>
 
-        <section>
-          <h2 id="how-to create a plugin">
-            <a href="#how-to create a plugin" class="section-link">
-              <span>How to Create a Plugin</span>
-              <span aria-hidden="true">#</span>
-            </a>
-          </h2>
-
-          <p>A plugin is an object that defines a set of intercept functions that should be run before or after a Kontra objects functions. These functions allow you to modify the code or change the behavior of the intercepted functions.</p>
-<p>An intercept function is named the same name as the function it will intercept. The function name is also prefixed with <code>before</code> to have the function run before the intercepted function, or <code>after</code> to run after the intercepted function.</p>
-<p>For example, if you wish to add a function to run after a Sprites <code>collidesWidth()</code> function, the name of the intercept function would be <code>afterCollidesWidth</code> (note the capitalization of the <code>collidesWidth</code> function name). <code>beforeCollidesWidth</code> would run before the Sprites <code>collidesWidth()</code> function.</p>
-<p>A plugin can define any number of before and after intercept functions. When the plugin is registered for a Kontra object, only intercept functions that match a function name in the Kontra object will be intercepted.</p>
-<p>As the plugin author, you should not <a href="#registerPlugin">register</a> the plugin yourself. You should only export the plugin object and let the consumer register it.</p>
-<pre><code class="lang-js">// pluginCode.js
-const loggingPlugin = {
-  afterCollidesWith(sprite, result, object) {
-    console.log(&#39;collision between sprites!&#39;);
-  }
-};
-export default loggingPlugin;
-</code></pre>
-<div class="tablist">
-  <ul role="tablist">
-    <li role="presentation" data-tab="global">
-      <button role="tab" id="how-to-create-a-plugin-global-tab">Global Object</button>
-    </li>
-    <li role="presentation" data-tab="es">
-      <button role="tab" id="how-to-create-a-plugin-es-tab">ES Module Import</button>
-    </li>
-    <li role="presentation" data-tab="bundle">
-      <button role="tab" id="how-to-create-a-plugin-bundle-tab">Module Bundler</button>
-    </li>
-    <li role="presentation"></li>
-  </ul>
-  <section role="tabpanel" aria-labelledby=how-to-create-a-plugin-global-tab data-tabpanel="global"><pre><code class="lang-js">// consumerCode.js
-let { registerPlugin, Sprite } = kontra;
-import loggingPlugin from pluginCode.js;
-
-// have the plugin run for all Sprites
-registerPlugin(Sprite, loggingPlugin);
-
-let sprite1 = Sprite({
-  x: 10,
-  y: 20,
-  width: 10,
-  height: 10
-});
-
-let sprite2 = Sprite({
-  x: 15,
-  y: 20,
-  width: 10,
-  height: 10
-});
-
-sprite1.collidesWith(sprite2);  //=&gt; &#39;collision between sprites!&#39;; true
-</code></pre></section>
-  <section role="tabpanel" aria-labelledby=how-to-create-a-plugin-es-tab data-tabpanel="es"><pre><code class="lang-js">// consumerCode.js
-import { registerPlugin, Sprite } from 'path/to/kontra.mjs';
-import loggingPlugin from pluginCode.js;
-
-// have the plugin run for all Sprites
-registerPlugin(Sprite, loggingPlugin);
-
-let sprite1 = Sprite({
-  x: 10,
-  y: 20,
-  width: 10,
-  height: 10
-});
-
-let sprite2 = Sprite({
-  x: 15,
-  y: 20,
-  width: 10,
-  height: 10
-});
-
-sprite1.collidesWith(sprite2);  //=&gt; &#39;collision between sprites!&#39;; true
-</code></pre></section>
-  <section role="tabpanel" aria-labelledby=how-to-create-a-plugin-bundle-tab data-tabpanel="bundle"><pre><code class="lang-js">// consumerCode.js
-import { registerPlugin, Sprite } from &#39;kontra&#39;;
-import loggingPlugin from pluginCode.js;
-
-// have the plugin run for all Sprites
-registerPlugin(Sprite, loggingPlugin);
-
-let sprite1 = Sprite({
-  x: 10,
-  y: 20,
-  width: 10,
-  height: 10
-});
-
-let sprite2 = Sprite({
-  x: 15,
-  y: 20,
-  width: 10,
-  height: 10
-});
-
-sprite1.collidesWith(sprite2);  //=&gt; &#39;collision between sprites!&#39;; true
-</code></pre></section>
-</div>
-        </section>
-        <section>
-          <h2 id="before-intercept functions">
-            <a href="#before-intercept functions" class="section-link">
-              <span>Before Intercept Functions</span>
-              <span aria-hidden="true">#</span>
-            </a>
-          </h2>
-
-          <p>A before intercept function can be used to modify or change the arguments that will be passed to the intercepted function.</p>
-<p>The function will be passed the <code>this</code> context of the intercepted object as well as all arguments of the original call. The function should either return an Array of the arguments if modifying them or return <code>null</code> or nothing if not modifying the arguments.</p>
-<pre><code class="lang-js">class MyObj {
-  add(a, b) {
-    return a + b;
-  }
-}
-
-// create a plugin that doubles the arguments before passing
-// them to the original add function
-registerPlugin(MyObj, {
-  beforeAdd(context, a, b) {
-    return [a * 2, b * 2];
-  }
-});
-
-const obj = new MyObj();
-obj.add(1, 2);  //=&gt; 6
-</code></pre>
-<p>Multiple before intercept functions can be registered for the same function. All functions will be run in the order they were registered. The functions return value will be passed to the next function. If the function doesn&#39;t modify the arguments (returned <code>null</code> or nothing) then the functions parameters will be passed to the next function instead.</p>
-<pre><code class="lang-js">class MyObj {
-  add(a, b) {
-    return a + b;
-  }
-}
-
-// log the arguments of the call and pass them unchanged to
-// the next plugin
-registerPlugin(MyObj, {
-  beforeAdd(context, a, b) {
-    console.log(`add passed: ${a}, ${b}`);
-  }
-});
-
-registerPlugin(MyObj, {
-  beforeAdd(context, a, b) {  // receives a=1 and b=2
-    return [a * 2, b * 2];
-  }
-});
-
-const obj = new MyObj();
-obj.add(1, 2);  //=&gt; &#39;add passed: 1, 2&#39;; 6
-</code></pre>
-        </section>
-        <section>
-          <h2 id="after-intercept functions">
-            <a href="#after-intercept functions" class="section-link">
-              <span>After Intercept Functions</span>
-              <span aria-hidden="true">#</span>
-            </a>
-          </h2>
-
-          <p>An after intercept function can be used to modify or change the results of the intercepted function.</p>
-<p>The function will be passed the <code>this</code> context of the intercepted object, the result of the intercepted function, and the final arguments passed to the intercepted function. The function should either return a value if modifying the result or return <code>null</code> or nothing if not modifying the result.</p>
-<pre><code class="lang-js">class MyObj {
-  add(a, b) {
-    return a + b;
-  }
-}
-
-// create a plugin that doubles the result
-registerPlugin(MyObj, {
-  afterAdd(context, result, a, b) {
-    return result * 2;
-  }
-});
-
-const obj = new MyObj();
-obj.add(1, 2);  //=&gt; 6
-</code></pre>
-<p>Multiple after intercept functions can be registered for the same function. All functions will be run in the order they were registered. Each functions return value will be passed to the next function. If the function doesn&#39;t modify the result (returned <code>null</code> or nothing) then the functions parameters will be passed to the next function instead.</p>
-<pre><code class="lang-js">class MyObj {
-  add(a, b) {
-    return a + b;
-  }
-}
-
-// log the arguments of the call and pass them unchanged to
-// the next plugin
-registerPlugin(MyObj, {
-  afterAdd(context, result, a, b) {
-    console.log(`add passed: ${a}, ${b} and returned ${result}`);
-  }
-});
-
-registerPlugin(MyObj, {
-  afterAdd(context, result, a, b) {  // receives result=3
-    return result * 2;
-  }
-});
-
-const obj = new MyObj();
-obj.add(1, 2);  //=&gt; &#39;add passed: 1, 2 and returned 3&#39;; 6
-</code></pre>
-        </section>
 
         <section>
           <h2 id="extendObject">
@@ -369,33 +151,30 @@ obj.add(1, 2);  //=&gt; &#39;add passed: 1, 2 and returned 3&#39;; 6
     </li>
     <li role="presentation"></li>
   </ul>
-  <section role="tabpanel" aria-labelledby=extendobject-global-tab data-tabpanel="global"><pre><code class="lang-js">let { extendObject, Vector } = kontra;
+  <section role="tabpanel" aria-labelledby=extendobject-global-tab data-tabpanel="global"><pre><code class="language-js">let { extendObject, Vector } = kontra;
 
 // add a subtract function to all Vectors
 extendObject(Vector, {
   subtract(vec) {
     return Vector(this.x - vec.x, this.y - vec.y);
   }
-});
-</code></pre></section>
-  <section role="tabpanel" aria-labelledby=extendobject-es-tab data-tabpanel="es"><pre><code class="lang-js">import { extendObject, Vector } from 'path/to/kontra.mjs';
+});</code></pre></section>
+  <section role="tabpanel" aria-labelledby=extendobject-es-tab data-tabpanel="es"><pre><code class="language-js">import { extendObject, Vector } from 'path/to/kontra.mjs';
 
 // add a subtract function to all Vectors
 extendObject(Vector, {
   subtract(vec) {
     return Vector(this.x - vec.x, this.y - vec.y);
   }
-});
-</code></pre></section>
-  <section role="tabpanel" aria-labelledby=extendobject-bundle-tab data-tabpanel="bundle"><pre><code class="lang-js">import { extendObject, Vector } from &#39;kontra&#39;;
+});</code></pre></section>
+  <section role="tabpanel" aria-labelledby=extendobject-bundle-tab data-tabpanel="bundle"><pre><code class="language-js">import { extendObject, Vector } from &#39;kontra&#39;;
 
 // add a subtract function to all Vectors
 extendObject(Vector, {
   subtract(vec) {
     return Vector(this.x - vec.x, this.y - vec.y);
   }
-});
-</code></pre></section>
+});</code></pre></section>
 </div>
           <h3 id="title-extendObject"><span class="visually-hidden">extendObject</span> Parameters</span></h3>
           <dl aria-labelledby="title-extendObject">

--- a/docs/api/pointer.html
+++ b/docs/api/pointer.html
@@ -83,7 +83,7 @@
     </li>
     <li role="presentation"></li>
   </ul>
-  <section role="tabpanel" aria-labelledby=pointer-global-tab data-tabpanel="global"><pre><code class="lang-js">let { initPointer, track, Sprite } = kontra;
+  <section role="tabpanel" aria-labelledby=pointer-global-tab data-tabpanel="global"><pre><code class="language-js">let { initPointer, track, Sprite } = kontra;
 
 // this function must be called first before pointer
 // functions will work
@@ -102,9 +102,8 @@ let sprite = Sprite({
 });
 
 track(sprite);
-sprite.render();
-</code></pre></section>
-  <section role="tabpanel" aria-labelledby=pointer-es-tab data-tabpanel="es"><pre><code class="lang-js">import { initPointer, track, Sprite } from 'path/to/kontra.mjs';
+sprite.render();</code></pre></section>
+  <section role="tabpanel" aria-labelledby=pointer-es-tab data-tabpanel="es"><pre><code class="language-js">import { initPointer, track, Sprite } from 'path/to/kontra.mjs';
 
 // this function must be called first before pointer
 // functions will work
@@ -123,9 +122,8 @@ let sprite = Sprite({
 });
 
 track(sprite);
-sprite.render();
-</code></pre></section>
-  <section role="tabpanel" aria-labelledby=pointer-bundle-tab data-tabpanel="bundle"><pre><code class="lang-js">import { initPointer, track, Sprite } from &#39;kontra&#39;;
+sprite.render();</code></pre></section>
+  <section role="tabpanel" aria-labelledby=pointer-bundle-tab data-tabpanel="bundle"><pre><code class="language-js">import { initPointer, track, Sprite } from &#39;kontra&#39;;
 
 // this function must be called first before pointer
 // functions will work
@@ -144,8 +142,7 @@ let sprite = Sprite({
 });
 
 track(sprite);
-sprite.render();
-</code></pre></section>
+sprite.render();</code></pre></section>
 </div>
 <p>By default, the pointer is treated as a circle and will check for collisions against objects assuming they are rectangular (have a width and height property).</p>
 <p>If you need to perform a different type of collision detection, assign the object a <code>collidesWithPointer()</code> function and it will be called instead. The function is passed the pointer object. Use this function to determine how the pointer circle should collide with the object.</p>
@@ -162,7 +159,7 @@ sprite.render();
     </li>
     <li role="presentation"></li>
   </ul>
-  <section role="tabpanel" aria-labelledby=pointer-global-tab data-tabpanel="global"><pre><code class="lang-js">let { Sprite } = kontra;
+  <section role="tabpanel" aria-labelledby=pointer-global-tab data-tabpanel="global"><pre><code class="language-js">let { Sprite } = kontra;
 
 let sprite = Srite({
   x: 10,
@@ -174,9 +171,8 @@ let sprite = Srite({
     let dy = pointer.y - this.y;
     return Math.sqrt(dx * dx + dy * dy) &lt; this.radius;
   }
-});
-</code></pre></section>
-  <section role="tabpanel" aria-labelledby=pointer-es-tab data-tabpanel="es"><pre><code class="lang-js">import { Sprite } from 'path/to/kontra.mjs';
+});</code></pre></section>
+  <section role="tabpanel" aria-labelledby=pointer-es-tab data-tabpanel="es"><pre><code class="language-js">import { Sprite } from 'path/to/kontra.mjs';
 
 let sprite = Srite({
   x: 10,
@@ -188,9 +184,8 @@ let sprite = Srite({
     let dy = pointer.y - this.y;
     return Math.sqrt(dx * dx + dy * dy) &lt; this.radius;
   }
-});
-</code></pre></section>
-  <section role="tabpanel" aria-labelledby=pointer-bundle-tab data-tabpanel="bundle"><pre><code class="lang-js">import { Sprite } from &#39;kontra&#39;;
+});</code></pre></section>
+  <section role="tabpanel" aria-labelledby=pointer-bundle-tab data-tabpanel="bundle"><pre><code class="language-js">import { Sprite } from &#39;kontra&#39;;
 
 let sprite = Srite({
   x: 10,
@@ -202,8 +197,7 @@ let sprite = Srite({
     let dy = pointer.y - this.y;
     return Math.sqrt(dx * dx + dy * dy) &lt; this.radius;
   }
-});
-</code></pre></section>
+});</code></pre></section>
 </div>
         
 
@@ -318,30 +312,27 @@ let sprite = Srite({
     </li>
     <li role="presentation"></li>
   </ul>
-  <section role="tabpanel" aria-labelledby=onpointerdown-global-tab data-tabpanel="global"><pre><code class="lang-js">let { initPointer, onPointerDown } = kontra;
+  <section role="tabpanel" aria-labelledby=onpointerdown-global-tab data-tabpanel="global"><pre><code class="language-js">let { initPointer, onPointerDown } = kontra;
 
 initPointer();
 
 onPointerDown(function(e, object) {
   // handle pointer down
-})
-</code></pre></section>
-  <section role="tabpanel" aria-labelledby=onpointerdown-es-tab data-tabpanel="es"><pre><code class="lang-js">import { initPointer, onPointerDown } from 'path/to/kontra.mjs';
+})</code></pre></section>
+  <section role="tabpanel" aria-labelledby=onpointerdown-es-tab data-tabpanel="es"><pre><code class="language-js">import { initPointer, onPointerDown } from 'path/to/kontra.mjs';
 
 initPointer();
 
 onPointerDown(function(e, object) {
   // handle pointer down
-})
-</code></pre></section>
-  <section role="tabpanel" aria-labelledby=onpointerdown-bundle-tab data-tabpanel="bundle"><pre><code class="lang-js">import { initPointer, onPointerDown } from &#39;kontra&#39;;
+})</code></pre></section>
+  <section role="tabpanel" aria-labelledby=onpointerdown-bundle-tab data-tabpanel="bundle"><pre><code class="language-js">import { initPointer, onPointerDown } from &#39;kontra&#39;;
 
 initPointer();
 
 onPointerDown(function(e, object) {
   // handle pointer down
-})
-</code></pre></section>
+})</code></pre></section>
 </div>
           <h3 id="title-onPointerDown"><span class="visually-hidden">onPointerDown</span> Parameters</span></h3>
           <dl aria-labelledby="title-onPointerDown">
@@ -376,30 +367,27 @@ onPointerDown(function(e, object) {
     </li>
     <li role="presentation"></li>
   </ul>
-  <section role="tabpanel" aria-labelledby=onpointerup-global-tab data-tabpanel="global"><pre><code class="lang-js">let { initPointer, onPointerUp } = kontra;
+  <section role="tabpanel" aria-labelledby=onpointerup-global-tab data-tabpanel="global"><pre><code class="language-js">let { initPointer, onPointerUp } = kontra;
 
 initPointer();
 
 onPointerUp(function(e, object) {
   // handle pointer up
-})
-</code></pre></section>
-  <section role="tabpanel" aria-labelledby=onpointerup-es-tab data-tabpanel="es"><pre><code class="lang-js">import { initPointer, onPointerUp } from 'path/to/kontra.mjs';
+})</code></pre></section>
+  <section role="tabpanel" aria-labelledby=onpointerup-es-tab data-tabpanel="es"><pre><code class="language-js">import { initPointer, onPointerUp } from 'path/to/kontra.mjs';
 
 initPointer();
 
 onPointerUp(function(e, object) {
   // handle pointer up
-})
-</code></pre></section>
-  <section role="tabpanel" aria-labelledby=onpointerup-bundle-tab data-tabpanel="bundle"><pre><code class="lang-js">import { initPointer, onPointerUp } from &#39;kontra&#39;;
+})</code></pre></section>
+  <section role="tabpanel" aria-labelledby=onpointerup-bundle-tab data-tabpanel="bundle"><pre><code class="language-js">import { initPointer, onPointerUp } from &#39;kontra&#39;;
 
 initPointer();
 
 onPointerUp(function(e, object) {
   // handle pointer up
-})
-</code></pre></section>
+})</code></pre></section>
 </div>
           <h3 id="title-onPointerUp"><span class="visually-hidden">onPointerUp</span> Parameters</span></h3>
           <dl aria-labelledby="title-onPointerUp">
@@ -434,24 +422,21 @@ onPointerUp(function(e, object) {
     </li>
     <li role="presentation"></li>
   </ul>
-  <section role="tabpanel" aria-labelledby=pointer-global-tab data-tabpanel="global"><pre><code class="lang-js">let { initPointer, pointer } = kontra;
+  <section role="tabpanel" aria-labelledby=pointer-global-tab data-tabpanel="global"><pre><code class="language-js">let { initPointer, pointer } = kontra;
 
 initPointer();
 
-console.log(pointer);  //=&gt; { x: 100, y: 200, radius: 5 };
-</code></pre></section>
-  <section role="tabpanel" aria-labelledby=pointer-es-tab data-tabpanel="es"><pre><code class="lang-js">import { initPointer, pointer } from 'path/to/kontra.mjs';
+console.log(pointer);  //=&gt; { x: 100, y: 200, radius: 5 };</code></pre></section>
+  <section role="tabpanel" aria-labelledby=pointer-es-tab data-tabpanel="es"><pre><code class="language-js">import { initPointer, pointer } from 'path/to/kontra.mjs';
 
 initPointer();
 
-console.log(pointer);  //=&gt; { x: 100, y: 200, radius: 5 };
-</code></pre></section>
-  <section role="tabpanel" aria-labelledby=pointer-bundle-tab data-tabpanel="bundle"><pre><code class="lang-js">import { initPointer, pointer } from &#39;kontra&#39;;
+console.log(pointer);  //=&gt; { x: 100, y: 200, radius: 5 };</code></pre></section>
+  <section role="tabpanel" aria-labelledby=pointer-bundle-tab data-tabpanel="bundle"><pre><code class="language-js">import { initPointer, pointer } from &#39;kontra&#39;;
 
 initPointer();
 
-console.log(pointer);  //=&gt; { x: 100, y: 200, radius: 5 };
-</code></pre></section>
+console.log(pointer);  //=&gt; { x: 100, y: 200, radius: 5 };</code></pre></section>
 </div>
           
         </section>
@@ -477,7 +462,7 @@ console.log(pointer);  //=&gt; { x: 100, y: 200, radius: 5 };
     </li>
     <li role="presentation"></li>
   </ul>
-  <section role="tabpanel" aria-labelledby=pointerover-global-tab data-tabpanel="global"><pre><code class="lang-js">let { initPointer, track, pointer, pointerOver, Sprite } = kontra;
+  <section role="tabpanel" aria-labelledby=pointerover-global-tab data-tabpanel="global"><pre><code class="language-js">let { initPointer, track, pointer, pointerOver, Sprite } = kontra;
 
 initPointer();
 
@@ -503,9 +488,8 @@ pointer.x = 14;
 pointer.y = 15;
 
 console.log(pointerOver(sprite1));  //=&gt; false
-console.log(pointerOver(sprite2));  //=&gt; true
-</code></pre></section>
-  <section role="tabpanel" aria-labelledby=pointerover-es-tab data-tabpanel="es"><pre><code class="lang-js">import { initPointer, track, pointer, pointerOver, Sprite } from 'path/to/kontra.mjs';
+console.log(pointerOver(sprite2));  //=&gt; true</code></pre></section>
+  <section role="tabpanel" aria-labelledby=pointerover-es-tab data-tabpanel="es"><pre><code class="language-js">import { initPointer, track, pointer, pointerOver, Sprite } from 'path/to/kontra.mjs';
 
 initPointer();
 
@@ -531,9 +515,8 @@ pointer.x = 14;
 pointer.y = 15;
 
 console.log(pointerOver(sprite1));  //=&gt; false
-console.log(pointerOver(sprite2));  //=&gt; true
-</code></pre></section>
-  <section role="tabpanel" aria-labelledby=pointerover-bundle-tab data-tabpanel="bundle"><pre><code class="lang-js">import { initPointer, track, pointer, pointerOver, Sprite } from &#39;kontra&#39;;
+console.log(pointerOver(sprite2));  //=&gt; true</code></pre></section>
+  <section role="tabpanel" aria-labelledby=pointerover-bundle-tab data-tabpanel="bundle"><pre><code class="language-js">import { initPointer, track, pointer, pointerOver, Sprite } from &#39;kontra&#39;;
 
 initPointer();
 
@@ -559,8 +542,7 @@ pointer.x = 14;
 pointer.y = 15;
 
 console.log(pointerOver(sprite1));  //=&gt; false
-console.log(pointerOver(sprite2));  //=&gt; true
-</code></pre></section>
+console.log(pointerOver(sprite2));  //=&gt; true</code></pre></section>
 </div>
           <h3 id="title-pointerOver"><span class="visually-hidden">pointerOver</span> Parameters</span></h3>
           <dl aria-labelledby="title-pointerOver">
@@ -598,7 +580,7 @@ console.log(pointerOver(sprite2));  //=&gt; true
     </li>
     <li role="presentation"></li>
   </ul>
-  <section role="tabpanel" aria-labelledby=pointerpressed-global-tab data-tabpanel="global"><pre><code class="lang-js">let { initPointer, pointerPressed } = kontra;
+  <section role="tabpanel" aria-labelledby=pointerpressed-global-tab data-tabpanel="global"><pre><code class="language-js">let { initPointer, pointerPressed } = kontra;
 
 initPointer();
 
@@ -611,9 +593,8 @@ Sprite({
       // right mouse button pressed
     }
   }
-});
-</code></pre></section>
-  <section role="tabpanel" aria-labelledby=pointerpressed-es-tab data-tabpanel="es"><pre><code class="lang-js">import { initPointer, pointerPressed } from 'path/to/kontra.mjs';
+});</code></pre></section>
+  <section role="tabpanel" aria-labelledby=pointerpressed-es-tab data-tabpanel="es"><pre><code class="language-js">import { initPointer, pointerPressed } from 'path/to/kontra.mjs';
 
 initPointer();
 
@@ -626,9 +607,8 @@ Sprite({
       // right mouse button pressed
     }
   }
-});
-</code></pre></section>
-  <section role="tabpanel" aria-labelledby=pointerpressed-bundle-tab data-tabpanel="bundle"><pre><code class="lang-js">import { initPointer, pointerPressed } from &#39;kontra&#39;;
+});</code></pre></section>
+  <section role="tabpanel" aria-labelledby=pointerpressed-bundle-tab data-tabpanel="bundle"><pre><code class="language-js">import { initPointer, pointerPressed } from &#39;kontra&#39;;
 
 initPointer();
 
@@ -641,8 +621,7 @@ Sprite({
       // right mouse button pressed
     }
   }
-});
-</code></pre></section>
+});</code></pre></section>
 </div>
           <h3 id="title-pointerPressed"><span class="visually-hidden">pointerPressed</span> Parameters</span></h3>
           <dl aria-labelledby="title-pointerPressed">
@@ -680,27 +659,24 @@ Sprite({
     </li>
     <li role="presentation"></li>
   </ul>
-  <section role="tabpanel" aria-labelledby=track-global-tab data-tabpanel="global"><pre><code class="lang-js">let { initPointer, track } = kontra;
+  <section role="tabpanel" aria-labelledby=track-global-tab data-tabpanel="global"><pre><code class="language-js">let { initPointer, track } = kontra;
 
 initPointer();
 
 track(obj);
-track([obj1, obj2]);
-</code></pre></section>
-  <section role="tabpanel" aria-labelledby=track-es-tab data-tabpanel="es"><pre><code class="lang-js">import { initPointer, track } from 'path/to/kontra.mjs';
+track([obj1, obj2]);</code></pre></section>
+  <section role="tabpanel" aria-labelledby=track-es-tab data-tabpanel="es"><pre><code class="language-js">import { initPointer, track } from 'path/to/kontra.mjs';
 
 initPointer();
 
 track(obj);
-track([obj1, obj2]);
-</code></pre></section>
-  <section role="tabpanel" aria-labelledby=track-bundle-tab data-tabpanel="bundle"><pre><code class="lang-js">import { initPointer, track } from &#39;kontra&#39;;
+track([obj1, obj2]);</code></pre></section>
+  <section role="tabpanel" aria-labelledby=track-bundle-tab data-tabpanel="bundle"><pre><code class="language-js">import { initPointer, track } from &#39;kontra&#39;;
 
 initPointer();
 
 track(obj);
-track([obj1, obj2]);
-</code></pre></section>
+track([obj1, obj2]);</code></pre></section>
 </div>
           <h3 id="title-track"><span class="visually-hidden">track</span> Parameters</span></h3>
           <dl aria-labelledby="title-track">
@@ -735,21 +711,18 @@ track([obj1, obj2]);
     </li>
     <li role="presentation"></li>
   </ul>
-  <section role="tabpanel" aria-labelledby=untrack-global-tab data-tabpanel="global"><pre><code class="lang-js">let { untrack } = kontra;
+  <section role="tabpanel" aria-labelledby=untrack-global-tab data-tabpanel="global"><pre><code class="language-js">let { untrack } = kontra;
 
 untrack(obj);
-untrack([obj1, obj2]);
-</code></pre></section>
-  <section role="tabpanel" aria-labelledby=untrack-es-tab data-tabpanel="es"><pre><code class="lang-js">import { untrack } from 'path/to/kontra.mjs';
+untrack([obj1, obj2]);</code></pre></section>
+  <section role="tabpanel" aria-labelledby=untrack-es-tab data-tabpanel="es"><pre><code class="language-js">import { untrack } from 'path/to/kontra.mjs';
 
 untrack(obj);
-untrack([obj1, obj2]);
-</code></pre></section>
-  <section role="tabpanel" aria-labelledby=untrack-bundle-tab data-tabpanel="bundle"><pre><code class="lang-js">import { untrack } from &#39;kontra&#39;;
+untrack([obj1, obj2]);</code></pre></section>
+  <section role="tabpanel" aria-labelledby=untrack-bundle-tab data-tabpanel="bundle"><pre><code class="language-js">import { untrack } from &#39;kontra&#39;;
 
 untrack(obj);
-untrack([obj1, obj2]);
-</code></pre></section>
+untrack([obj1, obj2]);</code></pre></section>
 </div>
           <h3 id="title-untrack"><span class="visually-hidden">untrack</span> Parameters</span></h3>
           <dl aria-labelledby="title-untrack">

--- a/docs/api/pool.html
+++ b/docs/api/pool.html
@@ -98,11 +98,6 @@
           <h2 id="toc"><a href="#toc" class="section-link">Table of Contents<span aria-hidden="true">#</span></a></h2>
 
           <ul aria-labelledby="toc">
-            <li>
-              <ul>
-                <li><a href="api/pool#basic-use">Basic Use</a></li>
-              </ul>
-            </li>
 
             <li>
               <h3 id="properties">Properties</h3>
@@ -158,132 +153,6 @@
           </ul>
         </section>
 
-        <section>
-          <h2 id="basic-use">
-            <a href="#basic-use" class="section-link">
-              <span>Basic Use</span>
-              <span aria-hidden="true">#</span>
-            </a>
-          </h2>
-
-          <p>To use the pool, you must pass the <code>create()</code> function argument, which should return a new <a href="Sprite">Sprite</a> or object. This object will be added to the pool every time there are no more alive objects.</p>
-<p>The object must implement the functions <code>update()</code>, <code>init()</code>, and <code>isAlive()</code>. If one of these functions is missing the pool will throw an error. <a href="Sprite">Sprite</a> defines these functions for you.</p>
-<p>An object is available for reuse when its <code>isAlive()</code> function returns <code>false</code>. For a sprite, this is typically when its ttl is <code>0</code>.</p>
-<p>When you want an object from the pool, use the pools <a href="#get">get()</a> function and pass it any properties you want the newly initialized object to have.</p>
-<div class="tablist">
-  <ul role="tablist">
-    <li role="presentation" data-tab="global">
-      <button role="tab" id="basic-use-global-tab">Global Object</button>
-    </li>
-    <li role="presentation" data-tab="es">
-      <button role="tab" id="basic-use-es-tab">ES Module Import</button>
-    </li>
-    <li role="presentation" data-tab="bundle">
-      <button role="tab" id="basic-use-bundle-tab">Module Bundler</button>
-    </li>
-    <li role="presentation"></li>
-  </ul>
-  <section role="tabpanel" aria-labelledby=basic-use-global-tab data-tabpanel="global"><pre><code class="lang-js">let { Pool, Sprite } = kontra;
-
-let pool = Pool({
-  // create a new sprite every time the pool needs a new object
-  create: Sprite
-});
-
-// properties will be passed to the sprites init() function
-pool.get({
-  x: 100,
-  y: 200,
-  width: 20,
-  height: 40,
-  color: &#39;red&#39;,
-  ttl: 60
-});
-</code></pre></section>
-  <section role="tabpanel" aria-labelledby=basic-use-es-tab data-tabpanel="es"><pre><code class="lang-js">import { Pool, Sprite } from 'path/to/kontra.mjs';
-
-let pool = Pool({
-  // create a new sprite every time the pool needs a new object
-  create: Sprite
-});
-
-// properties will be passed to the sprites init() function
-pool.get({
-  x: 100,
-  y: 200,
-  width: 20,
-  height: 40,
-  color: &#39;red&#39;,
-  ttl: 60
-});
-</code></pre></section>
-  <section role="tabpanel" aria-labelledby=basic-use-bundle-tab data-tabpanel="bundle"><pre><code class="lang-js">import { Pool, Sprite } from &#39;kontra&#39;;
-
-let pool = Pool({
-  // create a new sprite every time the pool needs a new object
-  create: Sprite
-});
-
-// properties will be passed to the sprites init() function
-pool.get({
-  x: 100,
-  y: 200,
-  width: 20,
-  height: 40,
-  color: &#39;red&#39;,
-  ttl: 60
-});
-</code></pre></section>
-</div>
-<p>When you want to update or render all alive objects in the pool, use the pools <a href="#update">update()</a> and <a href="#render">render()</a> functions.</p>
-<div class="tablist">
-  <ul role="tablist">
-    <li role="presentation" data-tab="global">
-      <button role="tab" id="basic-use-global-tab">Global Object</button>
-    </li>
-    <li role="presentation" data-tab="es">
-      <button role="tab" id="basic-use-es-tab">ES Module Import</button>
-    </li>
-    <li role="presentation" data-tab="bundle">
-      <button role="tab" id="basic-use-bundle-tab">Module Bundler</button>
-    </li>
-    <li role="presentation"></li>
-  </ul>
-  <section role="tabpanel" aria-labelledby=basic-use-global-tab data-tabpanel="global"><pre><code class="lang-js">let { GameLoop } = kontra;
-
-let loop = GameLoop({
-  update: function() {
-    pool.update();
-  },
-  render: function() {
-    pool.render();
-  }
-});
-</code></pre></section>
-  <section role="tabpanel" aria-labelledby=basic-use-es-tab data-tabpanel="es"><pre><code class="lang-js">import { GameLoop } from 'path/to/kontra.mjs';
-
-let loop = GameLoop({
-  update: function() {
-    pool.update();
-  },
-  render: function() {
-    pool.render();
-  }
-});
-</code></pre></section>
-  <section role="tabpanel" aria-labelledby=basic-use-bundle-tab data-tabpanel="bundle"><pre><code class="lang-js">import { GameLoop } from &#39;kontra&#39;;
-
-let loop = GameLoop({
-  update: function() {
-    pool.update();
-  },
-  render: function() {
-    pool.render();
-  }
-});
-</code></pre></section>
-</div>
-        </section>
 
         <section>
           <h2 id="clear">
@@ -306,7 +175,7 @@ let loop = GameLoop({
 
           <p>Get and return an object from the pool. The properties parameter will be passed directly to the objects <code>init()</code> function. If you&#39;re using a <a href="Sprite">Sprite</a>, you should also pass the <code>ttl</code> property to designate how many frames you want the object to be alive for.</p>
 <p>If you want to control when the sprite is ready for reuse, pass <code>Infinity</code> for <code>ttl</code>. You&#39;ll need to set the sprites <code>ttl</code> to <code>0</code> when you&#39;re ready for the sprite to be reused.</p>
-<pre><code class="lang-js">let sprite = pool.get({
+<pre><code class="language-js">let sprite = pool.get({
   // the object will get these properties and values
   x: 100,
   y: 200,
@@ -317,8 +186,7 @@ let loop = GameLoop({
   // pass Infinity for ttl to prevent the object from being reused
   // until you set it back to 0
   ttl: Infinity
-});
-</code></pre>
+});</code></pre>
           <h3 id="title-get"><span class="visually-hidden">get</span> Parameters</span></h3>
           <dl aria-labelledby="title-get">
             <dt>

--- a/docs/api/pool.html
+++ b/docs/api/pool.html
@@ -98,6 +98,11 @@
           <h2 id="toc"><a href="#toc" class="section-link">Table of Contents<span aria-hidden="true">#</span></a></h2>
 
           <ul aria-labelledby="toc">
+            <li>
+              <ul>
+                <li><a href="api/pool#basic-use">Basic Use</a></li>
+              </ul>
+            </li>
 
             <li>
               <h3 id="properties">Properties</h3>
@@ -153,6 +158,126 @@
           </ul>
         </section>
 
+        <section>
+          <h2 id="basic-use">
+            <a href="#basic-use" class="section-link">
+              <span>Basic Use</span>
+              <span aria-hidden="true">#</span>
+            </a>
+          </h2>
+
+          <p>To use the pool, you must pass the <code>create()</code> function argument, which should return a new <a href="Sprite">Sprite</a> or object. This object will be added to the pool every time there are no more alive objects.</p>
+<p>The object must implement the functions <code>update()</code>, <code>init()</code>, and <code>isAlive()</code>. If one of these functions is missing the pool will throw an error. <a href="Sprite">Sprite</a> defines these functions for you.</p>
+<p>An object is available for reuse when its <code>isAlive()</code> function returns <code>false</code>. For a sprite, this is typically when its ttl is <code>0</code>.</p>
+<p>When you want an object from the pool, use the pools <a href="#get">get()</a> function and pass it any properties you want the newly initialized object to have.</p>
+<div class="tablist">
+  <ul role="tablist">
+    <li role="presentation" data-tab="global">
+      <button role="tab" id="basic-use-global-tab">Global Object</button>
+    </li>
+    <li role="presentation" data-tab="es">
+      <button role="tab" id="basic-use-es-tab">ES Module Import</button>
+    </li>
+    <li role="presentation" data-tab="bundle">
+      <button role="tab" id="basic-use-bundle-tab">Module Bundler</button>
+    </li>
+    <li role="presentation"></li>
+  </ul>
+  <section role="tabpanel" aria-labelledby=basic-use-global-tab data-tabpanel="global"><pre><code class="language-js">let { Pool, Sprite } = kontra;
+
+let pool = Pool({
+  // create a new sprite every time the pool needs a new object
+  create: Sprite
+});
+
+// properties will be passed to the sprites init() function
+pool.get({
+  x: 100,
+  y: 200,
+  width: 20,
+  height: 40,
+  color: &#39;red&#39;,
+  ttl: 60
+});</code></pre></section>
+  <section role="tabpanel" aria-labelledby=basic-use-es-tab data-tabpanel="es"><pre><code class="language-js">import { Pool, Sprite } from 'path/to/kontra.mjs';
+
+let pool = Pool({
+  // create a new sprite every time the pool needs a new object
+  create: Sprite
+});
+
+// properties will be passed to the sprites init() function
+pool.get({
+  x: 100,
+  y: 200,
+  width: 20,
+  height: 40,
+  color: &#39;red&#39;,
+  ttl: 60
+});</code></pre></section>
+  <section role="tabpanel" aria-labelledby=basic-use-bundle-tab data-tabpanel="bundle"><pre><code class="language-js">import { Pool, Sprite } from &#39;kontra&#39;;
+
+let pool = Pool({
+  // create a new sprite every time the pool needs a new object
+  create: Sprite
+});
+
+// properties will be passed to the sprites init() function
+pool.get({
+  x: 100,
+  y: 200,
+  width: 20,
+  height: 40,
+  color: &#39;red&#39;,
+  ttl: 60
+});</code></pre></section>
+</div>
+<p>When you want to update or render all alive objects in the pool, use the pools <a href="#update">update()</a> and <a href="#render">render()</a> functions.</p>
+<div class="tablist">
+  <ul role="tablist">
+    <li role="presentation" data-tab="global">
+      <button role="tab" id="basic-use-global-tab">Global Object</button>
+    </li>
+    <li role="presentation" data-tab="es">
+      <button role="tab" id="basic-use-es-tab">ES Module Import</button>
+    </li>
+    <li role="presentation" data-tab="bundle">
+      <button role="tab" id="basic-use-bundle-tab">Module Bundler</button>
+    </li>
+    <li role="presentation"></li>
+  </ul>
+  <section role="tabpanel" aria-labelledby=basic-use-global-tab data-tabpanel="global"><pre><code class="language-js">let { GameLoop } = kontra;
+
+let loop = GameLoop({
+  update: function() {
+    pool.update();
+  },
+  render: function() {
+    pool.render();
+  }
+});</code></pre></section>
+  <section role="tabpanel" aria-labelledby=basic-use-es-tab data-tabpanel="es"><pre><code class="language-js">import { GameLoop } from 'path/to/kontra.mjs';
+
+let loop = GameLoop({
+  update: function() {
+    pool.update();
+  },
+  render: function() {
+    pool.render();
+  }
+});</code></pre></section>
+  <section role="tabpanel" aria-labelledby=basic-use-bundle-tab data-tabpanel="bundle"><pre><code class="language-js">import { GameLoop } from &#39;kontra&#39;;
+
+let loop = GameLoop({
+  update: function() {
+    pool.update();
+  },
+  render: function() {
+    pool.render();
+  }
+});</code></pre></section>
+</div>
+        </section>
 
         <section>
           <h2 id="clear">

--- a/docs/api/quadtree.html
+++ b/docs/api/quadtree.html
@@ -104,6 +104,11 @@
           <h2 id="toc"><a href="#toc" class="section-link">Table of Contents<span aria-hidden="true">#</span></a></h2>
 
           <ul aria-labelledby="toc">
+            <li>
+              <ul>
+                <li><a href="api/quadtree#basic-use">Basic Use</a></li>
+              </ul>
+            </li>
 
             <li>
               <h3 id="properties">Properties</h3>
@@ -149,6 +154,82 @@
           </ul>
         </section>
 
+        <section>
+          <h2 id="basic-use">
+            <a href="#basic-use" class="section-link">
+              <span>Basic Use</span>
+              <span aria-hidden="true">#</span>
+            </a>
+          </h2>
+
+          <p>Every frame you should remove all objects from the quadtree using its <a href="#clear">clear()</a> function and then add all objects back using its <a href="#add">add()</a> function. You can add a single object, a list of objects, or an array of objects.</p>
+<div class="tablist">
+  <ul role="tablist">
+    <li role="presentation" data-tab="global">
+      <button role="tab" id="basic-use-global-tab">Global Object</button>
+    </li>
+    <li role="presentation" data-tab="es">
+      <button role="tab" id="basic-use-es-tab">ES Module Import</button>
+    </li>
+    <li role="presentation" data-tab="bundle">
+      <button role="tab" id="basic-use-bundle-tab">Module Bundler</button>
+    </li>
+    <li role="presentation"></li>
+  </ul>
+  <section role="tabpanel" aria-labelledby=basic-use-global-tab data-tabpanel="global"><pre><code class="language-js">let { Quadtree, Sprite, GameLoop } = kontra;
+
+let quadtree = Quadtree();
+let player = Sprite({
+  // ...
+});
+let enemy = Sprite({
+  // ...
+});
+
+let loop = GameLoop({
+  update: function() {
+    quadtree.clear();
+    quadtree.add(player, enemy);
+  }
+});</code></pre></section>
+  <section role="tabpanel" aria-labelledby=basic-use-es-tab data-tabpanel="es"><pre><code class="language-js">import { Quadtree, Sprite, GameLoop } from 'path/to/kontra.mjs';
+
+let quadtree = Quadtree();
+let player = Sprite({
+  // ...
+});
+let enemy = Sprite({
+  // ...
+});
+
+let loop = GameLoop({
+  update: function() {
+    quadtree.clear();
+    quadtree.add(player, enemy);
+  }
+});</code></pre></section>
+  <section role="tabpanel" aria-labelledby=basic-use-bundle-tab data-tabpanel="bundle"><pre><code class="language-js">import { Quadtree, Sprite, GameLoop } from &#39;kontra&#39;;
+
+let quadtree = Quadtree();
+let player = Sprite({
+  // ...
+});
+let enemy = Sprite({
+  // ...
+});
+
+let loop = GameLoop({
+  update: function() {
+    quadtree.clear();
+    quadtree.add(player, enemy);
+  }
+});</code></pre></section>
+</div>
+<p>You should clear the quadtree each frame since the quadtree is only a snapshot of the position of the objects when they were added. Since the quadtree doesn&#39;t know anything about those objects, it doesn&#39;t know when an object moved or when it should be removed from the tree.</p>
+<p>Objects added to the tree must have the properties <code>x</code>, <code>y</code>, <code>width</code>, and <code>height</code> so that their position in the quadtree can be calculated. <a href="Sprite">Sprite</a> defines these properties for you.</p>
+<p>When you need to get all objects in the same node as another object, use the quadtrees <a href="#get">get()</a> function.</p>
+<pre><code class="language-js">let objects = quadtree.get(player);  //=&gt; [enemy]</code></pre>
+        </section>
 
         <section>
           <h2 id="add">

--- a/docs/api/quadtree.html
+++ b/docs/api/quadtree.html
@@ -104,11 +104,6 @@
           <h2 id="toc"><a href="#toc" class="section-link">Table of Contents<span aria-hidden="true">#</span></a></h2>
 
           <ul aria-labelledby="toc">
-            <li>
-              <ul>
-                <li><a href="api/quadtree#basic-use">Basic Use</a></li>
-              </ul>
-            </li>
 
             <li>
               <h3 id="properties">Properties</h3>
@@ -154,86 +149,6 @@
           </ul>
         </section>
 
-        <section>
-          <h2 id="basic-use">
-            <a href="#basic-use" class="section-link">
-              <span>Basic Use</span>
-              <span aria-hidden="true">#</span>
-            </a>
-          </h2>
-
-          <p>Every frame you should remove all objects from the quadtree using its <a href="#clear">clear()</a> function and then add all objects back using its <a href="#add">add()</a> function. You can add a single object, a list of objects, or an array of objects.</p>
-<div class="tablist">
-  <ul role="tablist">
-    <li role="presentation" data-tab="global">
-      <button role="tab" id="basic-use-global-tab">Global Object</button>
-    </li>
-    <li role="presentation" data-tab="es">
-      <button role="tab" id="basic-use-es-tab">ES Module Import</button>
-    </li>
-    <li role="presentation" data-tab="bundle">
-      <button role="tab" id="basic-use-bundle-tab">Module Bundler</button>
-    </li>
-    <li role="presentation"></li>
-  </ul>
-  <section role="tabpanel" aria-labelledby=basic-use-global-tab data-tabpanel="global"><pre><code class="lang-js">let { Quadtree, Sprite, GameLoop } = kontra;
-
-let quadtree = Quadtree();
-let player = Sprite({
-  // ...
-});
-let enemy = Sprite({
-  // ...
-});
-
-let loop = GameLoop({
-  update: function() {
-    quadtree.clear();
-    quadtree.add(player, enemy);
-  }
-});
-</code></pre></section>
-  <section role="tabpanel" aria-labelledby=basic-use-es-tab data-tabpanel="es"><pre><code class="lang-js">import { Quadtree, Sprite, GameLoop } from 'path/to/kontra.mjs';
-
-let quadtree = Quadtree();
-let player = Sprite({
-  // ...
-});
-let enemy = Sprite({
-  // ...
-});
-
-let loop = GameLoop({
-  update: function() {
-    quadtree.clear();
-    quadtree.add(player, enemy);
-  }
-});
-</code></pre></section>
-  <section role="tabpanel" aria-labelledby=basic-use-bundle-tab data-tabpanel="bundle"><pre><code class="lang-js">import { Quadtree, Sprite, GameLoop } from &#39;kontra&#39;;
-
-let quadtree = Quadtree();
-let player = Sprite({
-  // ...
-});
-let enemy = Sprite({
-  // ...
-});
-
-let loop = GameLoop({
-  update: function() {
-    quadtree.clear();
-    quadtree.add(player, enemy);
-  }
-});
-</code></pre></section>
-</div>
-<p>You should clear the quadtree each frame since the quadtree is only a snapshot of the position of the objects when they were added. Since the quadtree doesn&#39;t know anything about those objects, it doesn&#39;t know when an object moved or when it should be removed from the tree.</p>
-<p>Objects added to the tree must have the properties <code>x</code>, <code>y</code>, <code>width</code>, and <code>height</code> so that their position in the quadtree can be calculated. <a href="Sprite">Sprite</a> defines these properties for you.</p>
-<p>When you need to get all objects in the same node as another object, use the quadtrees <a href="#get">get()</a> function.</p>
-<pre><code class="lang-js">let objects = quadtree.get(player);  //=&gt; [enemy]
-</code></pre>
-        </section>
 
         <section>
           <h2 id="add">
@@ -257,7 +172,7 @@ let loop = GameLoop({
     </li>
     <li role="presentation"></li>
   </ul>
-  <section role="tabpanel" aria-labelledby=add-global-tab data-tabpanel="global"><pre><code class="lang-js">let { Quadtree, Sprite, Pool, GameLoop } = kontra;
+  <section role="tabpanel" aria-labelledby=add-global-tab data-tabpanel="global"><pre><code class="language-js">let { Quadtree, Sprite, Pool, GameLoop } = kontra;
 
 let quadtree = Quadtree();
 let bulletPool = Pool({
@@ -283,9 +198,8 @@ let loop = GameLoop({
     quadtree.clear();
     quadtree.add(player, enemy, bulletPool.getAliveObjects());
   }
-});
-</code></pre></section>
-  <section role="tabpanel" aria-labelledby=add-es-tab data-tabpanel="es"><pre><code class="lang-js">import { Quadtree, Sprite, Pool, GameLoop } from 'path/to/kontra.mjs';
+});</code></pre></section>
+  <section role="tabpanel" aria-labelledby=add-es-tab data-tabpanel="es"><pre><code class="language-js">import { Quadtree, Sprite, Pool, GameLoop } from 'path/to/kontra.mjs';
 
 let quadtree = Quadtree();
 let bulletPool = Pool({
@@ -311,9 +225,8 @@ let loop = GameLoop({
     quadtree.clear();
     quadtree.add(player, enemy, bulletPool.getAliveObjects());
   }
-});
-</code></pre></section>
-  <section role="tabpanel" aria-labelledby=add-bundle-tab data-tabpanel="bundle"><pre><code class="lang-js">import { Quadtree, Sprite, Pool, GameLoop } from &#39;kontra&#39;;
+});</code></pre></section>
+  <section role="tabpanel" aria-labelledby=add-bundle-tab data-tabpanel="bundle"><pre><code class="language-js">import { Quadtree, Sprite, Pool, GameLoop } from &#39;kontra&#39;;
 
 let quadtree = Quadtree();
 let bulletPool = Pool({
@@ -339,8 +252,7 @@ let loop = GameLoop({
     quadtree.clear();
     quadtree.add(player, enemy, bulletPool.getAliveObjects());
   }
-});
-</code></pre></section>
+});</code></pre></section>
 </div>
           <h3 id="title-add"><span class="visually-hidden">add</span> Parameters</span></h3>
           <dl aria-labelledby="title-add">
@@ -398,7 +310,7 @@ let loop = GameLoop({
     </li>
     <li role="presentation"></li>
   </ul>
-  <section role="tabpanel" aria-labelledby=get-global-tab data-tabpanel="global"><pre><code class="lang-js">let { Sprite, Quadtree } = kontra;
+  <section role="tabpanel" aria-labelledby=get-global-tab data-tabpanel="global"><pre><code class="language-js">let { Sprite, Quadtree } = kontra;
 
 let quadtree = Quadtree();
 let player = Sprite({
@@ -412,9 +324,8 @@ let enemy2 = Sprite({
 });
 
 quadtree.add(player, enemy1, enemy2);
-quadtree.get(player);  //=&gt; [enemy1]
-</code></pre></section>
-  <section role="tabpanel" aria-labelledby=get-es-tab data-tabpanel="es"><pre><code class="lang-js">import { Sprite, Quadtree } from 'path/to/kontra.mjs';
+quadtree.get(player);  //=&gt; [enemy1]</code></pre></section>
+  <section role="tabpanel" aria-labelledby=get-es-tab data-tabpanel="es"><pre><code class="language-js">import { Sprite, Quadtree } from 'path/to/kontra.mjs';
 
 let quadtree = Quadtree();
 let player = Sprite({
@@ -428,9 +339,8 @@ let enemy2 = Sprite({
 });
 
 quadtree.add(player, enemy1, enemy2);
-quadtree.get(player);  //=&gt; [enemy1]
-</code></pre></section>
-  <section role="tabpanel" aria-labelledby=get-bundle-tab data-tabpanel="bundle"><pre><code class="lang-js">import { Sprite, Quadtree } from &#39;kontra&#39;;
+quadtree.get(player);  //=&gt; [enemy1]</code></pre></section>
+  <section role="tabpanel" aria-labelledby=get-bundle-tab data-tabpanel="bundle"><pre><code class="language-js">import { Sprite, Quadtree } from &#39;kontra&#39;;
 
 let quadtree = Quadtree();
 let player = Sprite({
@@ -444,8 +354,7 @@ let enemy2 = Sprite({
 });
 
 quadtree.add(player, enemy1, enemy2);
-quadtree.get(player);  //=&gt; [enemy1]
-</code></pre></section>
+quadtree.get(player);  //=&gt; [enemy1]</code></pre></section>
 </div>
           <h3 id="title-get"><span class="visually-hidden">get</span> Parameters</span></h3>
           <dl aria-labelledby="title-get">

--- a/docs/api/sprite.html
+++ b/docs/api/sprite.html
@@ -192,6 +192,15 @@
           <h2 id="toc"><a href="#toc" class="section-link">Table of Contents<span aria-hidden="true">#</span></a></h2>
 
           <ul aria-labelledby="toc">
+            <li>
+              <ul>
+                <li><a href="api/sprite#rectangle-sprite">Rectangle Sprite</a></li>
+                <li><a href="api/sprite#image-sprite">Image Sprite</a></li>
+                <li><a href="api/sprite#animation-sprite">Animation Sprite</a></li>
+                <li><a href="api/sprite#custom-properties">Custom Properties</a></li>
+                <li><a href="api/sprite#extending-a sprite">Extending a Sprite</a></li>
+              </ul>
+            </li>
 
             <li>
               <h3 id="properties">Properties</h3>
@@ -342,6 +351,593 @@
           </ul>
         </section>
 
+        <section>
+          <h2 id="rectangle-sprite">
+            <a href="#rectangle-sprite" class="section-link">
+              <span>Rectangle Sprite</span>
+              <span aria-hidden="true">#</span>
+            </a>
+          </h2>
+
+          <p>In its most basic form, a sprite is a rectangle with a fill color. To create a rectangle sprite, pass the arguments <code>width</code>, <code>height</code>, and <code>color</code>. A rectangle sprite is great for initial prototyping and particles.</p>
+<canvas id="game-canvas-0"></canvas>
+
+<div class="tablist">
+  <ul role="tablist">
+    <li role="presentation" data-tab="global">
+      <button role="tab" id="game-canvas-0-global-tab">Global Object</button>
+    </li>
+    <li role="presentation" data-tab="es">
+      <button role="tab" id="game-canvas-0-es-tab">ES Module Import</button>
+    </li>
+    <li role="presentation" data-tab="bundle">
+      <button role="tab" id="game-canvas-0-bundle-tab">Module Bundler</button>
+    </li>
+    <li role="presentation"></li>
+  </ul>
+  <section role="tabpanel" aria-labelledby=game-canvas-0-global-tab data-tabpanel="global">
+    <pre><code class="lang-js">let { Sprite } &#x3D; kontra
+
+let sprite &#x3D; Sprite({
+  x: 300,
+  y: 100,
+  anchor: {x: 0.5, y: 0.5},
+
+  // required for a rectangle sprite
+  width: 20,
+  height: 40,
+  color: &#x27;red&#x27;
+});
+
+sprite.render();</code></pre>
+  </section>
+  <section role="tabpanel" aria-labelledby=game-canvas-0-es-tab data-tabpanel="es">
+    <pre><code class="lang-js">import { Sprite } from &#x27;path/to/kontra.mjs&#x27;
+
+let sprite &#x3D; Sprite({
+  x: 300,
+  y: 100,
+  anchor: {x: 0.5, y: 0.5},
+
+  // required for a rectangle sprite
+  width: 20,
+  height: 40,
+  color: &#x27;red&#x27;
+});
+
+sprite.render();</code></pre>
+  </section>
+  <section role="tabpanel" aria-labelledby=game-canvas-0-bundle-tab data-tabpanel="bundle">
+    <pre><code class="lang-js">import { Sprite } from &#x27;kontra&#x27;;
+
+let sprite &#x3D; Sprite({
+  x: 300,
+  y: 100,
+  anchor: {x: 0.5, y: 0.5},
+
+  // required for a rectangle sprite
+  width: 20,
+  height: 40,
+  color: &#x27;red&#x27;
+});
+
+sprite.render();</code></pre>
+  </section>
+</div>
+
+<script>(function() {
+  kontra.init("game-canvas-0");
+  var canvas = document.querySelector("#game-canvas-0");
+  canvas.width = 600;
+  canvas.height = 200;
+  var context = canvas.getContext("2d");
+  // exclude-code:start
+let { Sprite } = kontra;
+// exclude-code:end
+let sprite = Sprite({
+  x: 300,
+  y: 100,
+  anchor: {x: 0.5, y: 0.5},
+
+  // required for a rectangle sprite
+  width: 20,
+  height: 40,
+  color: 'red'
+});
+// exclude-code:start
+sprite.context = context;
+// exclude-code:end
+
+sprite.render();
+})();</script>        </section>
+        <section>
+          <h2 id="image-sprite">
+            <a href="#image-sprite" class="section-link">
+              <span>Image Sprite</span>
+              <span aria-hidden="true">#</span>
+            </a>
+          </h2>
+
+          <p>A sprite can use an image instead of drawing a rectangle. To create an image sprite, pass the <code>image</code> argument. The size of the sprite will automatically be set as the width and height of the image.</p>
+<canvas id="game-canvas-1"></canvas>
+
+<div class="tablist">
+  <ul role="tablist">
+    <li role="presentation" data-tab="global">
+      <button role="tab" id="game-canvas-1-global-tab">Global Object</button>
+    </li>
+    <li role="presentation" data-tab="es">
+      <button role="tab" id="game-canvas-1-es-tab">ES Module Import</button>
+    </li>
+    <li role="presentation" data-tab="bundle">
+      <button role="tab" id="game-canvas-1-bundle-tab">Module Bundler</button>
+    </li>
+    <li role="presentation"></li>
+  </ul>
+  <section role="tabpanel" aria-labelledby=game-canvas-1-global-tab data-tabpanel="global">
+    <pre><code class="lang-js">let { Sprite } &#x3D; kontra
+
+let image &#x3D; new Image();
+image.src &#x3D; &#x27;assets/imgs/character.png&#x27;;
+image.onload &#x3D; function() {
+  let sprite &#x3D; Sprite({
+    x: 300,
+    y: 100,
+    anchor: {x: 0.5, y: 0.5},
+
+    // required for an image sprite
+    image: image
+  });
+
+  sprite.render();
+};</code></pre>
+  </section>
+  <section role="tabpanel" aria-labelledby=game-canvas-1-es-tab data-tabpanel="es">
+    <pre><code class="lang-js">import { Sprite } from &#x27;path/to/kontra.mjs&#x27;
+
+let image &#x3D; new Image();
+image.src &#x3D; &#x27;assets/imgs/character.png&#x27;;
+image.onload &#x3D; function() {
+  let sprite &#x3D; Sprite({
+    x: 300,
+    y: 100,
+    anchor: {x: 0.5, y: 0.5},
+
+    // required for an image sprite
+    image: image
+  });
+
+  sprite.render();
+};</code></pre>
+  </section>
+  <section role="tabpanel" aria-labelledby=game-canvas-1-bundle-tab data-tabpanel="bundle">
+    <pre><code class="lang-js">import { Sprite } from &#x27;kontra&#x27;;
+
+let image &#x3D; new Image();
+image.src &#x3D; &#x27;assets/imgs/character.png&#x27;;
+image.onload &#x3D; function() {
+  let sprite &#x3D; Sprite({
+    x: 300,
+    y: 100,
+    anchor: {x: 0.5, y: 0.5},
+
+    // required for an image sprite
+    image: image
+  });
+
+  sprite.render();
+};</code></pre>
+  </section>
+</div>
+
+<script>(function() {
+  kontra.init("game-canvas-1");
+  var canvas = document.querySelector("#game-canvas-1");
+  canvas.width = 600;
+  canvas.height = 200;
+  var context = canvas.getContext("2d");
+  // exclude-code:start
+let { Sprite } = kontra;
+// exclude-code:end
+let image = new Image();
+image.src = 'assets/imgs/character.png';
+image.onload = function() {
+  let sprite = Sprite({
+    x: 300,
+    y: 100,
+    anchor: {x: 0.5, y: 0.5},
+
+    // required for an image sprite
+    image: image
+  });
+  // exclude-code:start
+  sprite.context = context;
+  // exclude-code:end
+
+  sprite.render();
+};
+})();</script>        </section>
+        <section>
+          <h2 id="animation-sprite">
+            <a href="#animation-sprite" class="section-link">
+              <span>Animation Sprite</span>
+              <span aria-hidden="true">#</span>
+            </a>
+          </h2>
+
+          <p>A sprite can use a spritesheet animation as well. To create an animation sprite, pass the <code>animations</code> argument. The size of the sprite will automatically be set as the width and height of a frame of the spritesheet.</p>
+<p>A sprite can have multiple named animations. The easiest way to create animations is to use <a href="SpriteSheet">SpriteSheet</a>. All animations will automatically be <a href="animation#clone">cloned</a> so no two sprites update the same animation.</p>
+<canvas id="game-canvas-2"></canvas>
+
+<div class="tablist">
+  <ul role="tablist">
+    <li role="presentation" data-tab="global">
+      <button role="tab" id="game-canvas-2-global-tab">Global Object</button>
+    </li>
+    <li role="presentation" data-tab="es">
+      <button role="tab" id="game-canvas-2-es-tab">ES Module Import</button>
+    </li>
+    <li role="presentation" data-tab="bundle">
+      <button role="tab" id="game-canvas-2-bundle-tab">Module Bundler</button>
+    </li>
+    <li role="presentation"></li>
+  </ul>
+  <section role="tabpanel" aria-labelledby=game-canvas-2-global-tab data-tabpanel="global">
+    <pre><code class="lang-js">let { Sprite, SpriteSheet, GameLoop } &#x3D; kontra
+
+let image &#x3D; new Image();
+image.src &#x3D; &#x27;assets/imgs/character_walk_sheet.png&#x27;;
+image.onload &#x3D; function() {
+
+  // use spriteSheet to create animations from an image
+  let spriteSheet &#x3D; SpriteSheet({
+    image: image,
+    frameWidth: 72,
+    frameHeight: 97,
+    animations: {
+      // create a named animation: walk
+      walk: {
+        frames: &#x27;0..9&#x27;,  // frames 0 through 9
+        frameRate: 30
+      }
+    }
+  });
+
+  let sprite &#x3D; Sprite({
+    x: 300,
+    y: 100,
+    anchor: {x: 0.5, y: 0.5},
+
+    // required for an animation sprite
+    animations: spriteSheet.animations
+  });
+
+  // use kontra.gameLoop to play the animation
+  let loop &#x3D; GameLoop({
+    update: function(dt) {
+      sprite.update();
+    },
+    render: function() {
+      sprite.render();
+    }
+  });
+
+  loop.start();
+};</code></pre>
+  </section>
+  <section role="tabpanel" aria-labelledby=game-canvas-2-es-tab data-tabpanel="es">
+    <pre><code class="lang-js">import { Sprite, SpriteSheet, GameLoop } from &#x27;path/to/kontra.mjs&#x27;
+
+let image &#x3D; new Image();
+image.src &#x3D; &#x27;assets/imgs/character_walk_sheet.png&#x27;;
+image.onload &#x3D; function() {
+
+  // use spriteSheet to create animations from an image
+  let spriteSheet &#x3D; SpriteSheet({
+    image: image,
+    frameWidth: 72,
+    frameHeight: 97,
+    animations: {
+      // create a named animation: walk
+      walk: {
+        frames: &#x27;0..9&#x27;,  // frames 0 through 9
+        frameRate: 30
+      }
+    }
+  });
+
+  let sprite &#x3D; Sprite({
+    x: 300,
+    y: 100,
+    anchor: {x: 0.5, y: 0.5},
+
+    // required for an animation sprite
+    animations: spriteSheet.animations
+  });
+
+  // use kontra.gameLoop to play the animation
+  let loop &#x3D; GameLoop({
+    update: function(dt) {
+      sprite.update();
+    },
+    render: function() {
+      sprite.render();
+    }
+  });
+
+  loop.start();
+};</code></pre>
+  </section>
+  <section role="tabpanel" aria-labelledby=game-canvas-2-bundle-tab data-tabpanel="bundle">
+    <pre><code class="lang-js">import { Sprite, SpriteSheet, GameLoop } from &#x27;kontra&#x27;;
+
+let image &#x3D; new Image();
+image.src &#x3D; &#x27;assets/imgs/character_walk_sheet.png&#x27;;
+image.onload &#x3D; function() {
+
+  // use spriteSheet to create animations from an image
+  let spriteSheet &#x3D; SpriteSheet({
+    image: image,
+    frameWidth: 72,
+    frameHeight: 97,
+    animations: {
+      // create a named animation: walk
+      walk: {
+        frames: &#x27;0..9&#x27;,  // frames 0 through 9
+        frameRate: 30
+      }
+    }
+  });
+
+  let sprite &#x3D; Sprite({
+    x: 300,
+    y: 100,
+    anchor: {x: 0.5, y: 0.5},
+
+    // required for an animation sprite
+    animations: spriteSheet.animations
+  });
+
+  // use kontra.gameLoop to play the animation
+  let loop &#x3D; GameLoop({
+    update: function(dt) {
+      sprite.update();
+    },
+    render: function() {
+      sprite.render();
+    }
+  });
+
+  loop.start();
+};</code></pre>
+  </section>
+</div>
+
+<script>(function() {
+  kontra.init("game-canvas-2");
+  var canvas = document.querySelector("#game-canvas-2");
+  canvas.width = 600;
+  canvas.height = 200;
+  var context = canvas.getContext("2d");
+  // exclude-code:start
+let { Sprite, SpriteSheet, GameLoop } = kontra;
+// exclude-code:end
+let image = new Image();
+image.src = 'assets/imgs/character_walk_sheet.png';
+image.onload = function() {
+
+  // use spriteSheet to create animations from an image
+  let spriteSheet = SpriteSheet({
+    image: image,
+    frameWidth: 72,
+    frameHeight: 97,
+    animations: {
+      // create a named animation: walk
+      walk: {
+        frames: '0..9',  // frames 0 through 9
+        frameRate: 30
+      }
+    }
+  });
+
+  let sprite = Sprite({
+    x: 300,
+    y: 100,
+    anchor: {x: 0.5, y: 0.5},
+
+    // required for an animation sprite
+    animations: spriteSheet.animations
+  });
+  // exclude-code:start
+  sprite.context = context;
+  // exclude-code:end
+
+  // use kontra.gameLoop to play the animation
+  let loop = GameLoop({
+  // exclude-code:start
+  clearCanvas: false,
+  // exclude-code:end
+    update: function(dt) {
+      sprite.update();
+    },
+    render: function() {
+      // exclude-code:start
+      context.clearRect(0,0,context.canvas.width,context.canvas.height);
+      // exclude-code:end
+      sprite.render();
+    }
+  });
+
+  loop.start();
+};
+})();</script>        </section>
+        <section>
+          <h2 id="custom-properties">
+            <a href="#custom-properties" class="section-link">
+              <span>Custom Properties</span>
+              <span aria-hidden="true">#</span>
+            </a>
+          </h2>
+
+          <p>If you need to draw a different shape, such as a circle, you can pass in custom properties and a render function to handle drawing the sprite.</p>
+<canvas id="game-canvas-3"></canvas>
+
+<div class="tablist">
+  <ul role="tablist">
+    <li role="presentation" data-tab="global">
+      <button role="tab" id="game-canvas-3-global-tab">Global Object</button>
+    </li>
+    <li role="presentation" data-tab="es">
+      <button role="tab" id="game-canvas-3-es-tab">ES Module Import</button>
+    </li>
+    <li role="presentation" data-tab="bundle">
+      <button role="tab" id="game-canvas-3-bundle-tab">Module Bundler</button>
+    </li>
+    <li role="presentation"></li>
+  </ul>
+  <section role="tabpanel" aria-labelledby=game-canvas-3-global-tab data-tabpanel="global">
+    <pre><code class="lang-js">let { Sprite } &#x3D; kontra
+
+let sprite &#x3D; Sprite({
+  x: 300,
+  y: 100,
+
+  color: &#x27;red&#x27;,
+
+  // custom properties
+  radius: 20,
+
+  render: function() {
+    this.context.fillStyle &#x3D; this.color;
+
+    this.context.beginPath();
+    this.context.arc(this.x, this.y, this.radius, 0, 2  * Math.PI);
+    this.context.fill();
+  }
+});
+
+sprite.render();</code></pre>
+  </section>
+  <section role="tabpanel" aria-labelledby=game-canvas-3-es-tab data-tabpanel="es">
+    <pre><code class="lang-js">import { Sprite } from &#x27;path/to/kontra.mjs&#x27;
+
+let sprite &#x3D; Sprite({
+  x: 300,
+  y: 100,
+
+  color: &#x27;red&#x27;,
+
+  // custom properties
+  radius: 20,
+
+  render: function() {
+    this.context.fillStyle &#x3D; this.color;
+
+    this.context.beginPath();
+    this.context.arc(this.x, this.y, this.radius, 0, 2  * Math.PI);
+    this.context.fill();
+  }
+});
+
+sprite.render();</code></pre>
+  </section>
+  <section role="tabpanel" aria-labelledby=game-canvas-3-bundle-tab data-tabpanel="bundle">
+    <pre><code class="lang-js">import { Sprite } from &#x27;kontra&#x27;;
+
+let sprite &#x3D; Sprite({
+  x: 300,
+  y: 100,
+
+  color: &#x27;red&#x27;,
+
+  // custom properties
+  radius: 20,
+
+  render: function() {
+    this.context.fillStyle &#x3D; this.color;
+
+    this.context.beginPath();
+    this.context.arc(this.x, this.y, this.radius, 0, 2  * Math.PI);
+    this.context.fill();
+  }
+});
+
+sprite.render();</code></pre>
+  </section>
+</div>
+
+<script>(function() {
+  kontra.init("game-canvas-3");
+  var canvas = document.querySelector("#game-canvas-3");
+  canvas.width = 600;
+  canvas.height = 200;
+  var context = canvas.getContext("2d");
+  // exclude-code:start
+let { Sprite } = kontra;
+// exclude-code:end
+let sprite = Sprite({
+  x: 300,
+  y: 100,
+
+  color: 'red',
+
+  // custom properties
+  radius: 20,
+
+  render: function() {
+    this.context.fillStyle = this.color;
+
+    this.context.beginPath();
+    this.context.arc(this.x, this.y, this.radius, 0, 2  * Math.PI);
+    this.context.fill();
+  }
+});
+// exclude-code:start
+sprite.context = context;
+// exclude-code:end
+
+sprite.render();
+})();</script>        </section>
+        <section>
+          <h2 id="extending-a sprite">
+            <a href="#extending-a sprite" class="section-link">
+              <span>Extending a Sprite</span>
+              <span aria-hidden="true">#</span>
+            </a>
+          </h2>
+
+          <p>If you want to extend a Sprite, you can do so by extending the Sprite class. The one caveat is that <code>Sprite</code> is not the Sprite class, but actually is a factory function.</p>
+<p>To extend the Sprite class, use the <code>.class</code> property of the constructor.</p>
+<div class="tablist">
+  <ul role="tablist">
+    <li role="presentation" data-tab="global">
+      <button role="tab" id="extending-a-sprite-global-tab">Global Object</button>
+    </li>
+    <li role="presentation" data-tab="es">
+      <button role="tab" id="extending-a-sprite-es-tab">ES Module Import</button>
+    </li>
+    <li role="presentation" data-tab="bundle">
+      <button role="tab" id="extending-a-sprite-bundle-tab">Module Bundler</button>
+    </li>
+    <li role="presentation"></li>
+  </ul>
+  <section role="tabpanel" aria-labelledby=extending-a-sprite-global-tab data-tabpanel="global"><pre><code class="language-js">let { Sprite } = kontra;
+
+class CustomSprite extends Sprite.class {
+  // ...
+}</code></pre></section>
+  <section role="tabpanel" aria-labelledby=extending-a-sprite-es-tab data-tabpanel="es"><pre><code class="language-js">import { Sprite } from 'path/to/kontra.mjs';
+
+class CustomSprite extends Sprite.class {
+  // ...
+}</code></pre></section>
+  <section role="tabpanel" aria-labelledby=extending-a-sprite-bundle-tab data-tabpanel="bundle"><pre><code class="language-js">import { Sprite } from &#39;kontra&#39;;
+
+class CustomSprite extends Sprite.class {
+  // ...
+}</code></pre></section>
+</div>
+        </section>
 
         <section>
           <h2 id="acceleration">
@@ -470,22 +1066,22 @@ let sprite = Sprite({
           </h2>
 
           <p>The x and y origin of the sprite. {x:0, y:0} is the top left corner of the sprite, {x:1, y:1} is the bottom right corner.</p>
-<canvas id="game-canvas-0"></canvas>
+<canvas id="game-canvas-4"></canvas>
 
 <div class="tablist">
   <ul role="tablist">
     <li role="presentation" data-tab="global">
-      <button role="tab" id="game-canvas-0-global-tab">Global Object</button>
+      <button role="tab" id="game-canvas-4-global-tab">Global Object</button>
     </li>
     <li role="presentation" data-tab="es">
-      <button role="tab" id="game-canvas-0-es-tab">ES Module Import</button>
+      <button role="tab" id="game-canvas-4-es-tab">ES Module Import</button>
     </li>
     <li role="presentation" data-tab="bundle">
-      <button role="tab" id="game-canvas-0-bundle-tab">Module Bundler</button>
+      <button role="tab" id="game-canvas-4-bundle-tab">Module Bundler</button>
     </li>
     <li role="presentation"></li>
   </ul>
-  <section role="tabpanel" aria-labelledby=game-canvas-0-global-tab data-tabpanel="global">
+  <section role="tabpanel" aria-labelledby=game-canvas-4-global-tab data-tabpanel="global">
     <pre><code class="lang-js">let { Sprite } &#x3D; kontra
 
 let sprite &#x3D; Sprite({
@@ -514,7 +1110,7 @@ sprite.anchor &#x3D; {x: 1, y: 1};
 sprite.x &#x3D; 450;
 sprite.render();</code></pre>
   </section>
-  <section role="tabpanel" aria-labelledby=game-canvas-0-es-tab data-tabpanel="es">
+  <section role="tabpanel" aria-labelledby=game-canvas-4-es-tab data-tabpanel="es">
     <pre><code class="lang-js">import { Sprite } from &#x27;path/to/kontra.mjs&#x27;
 
 let sprite &#x3D; Sprite({
@@ -543,7 +1139,7 @@ sprite.anchor &#x3D; {x: 1, y: 1};
 sprite.x &#x3D; 450;
 sprite.render();</code></pre>
   </section>
-  <section role="tabpanel" aria-labelledby=game-canvas-0-bundle-tab data-tabpanel="bundle">
+  <section role="tabpanel" aria-labelledby=game-canvas-4-bundle-tab data-tabpanel="bundle">
     <pre><code class="lang-js">import { Sprite } from &#x27;kontra&#x27;;
 
 let sprite &#x3D; Sprite({
@@ -575,8 +1171,8 @@ sprite.render();</code></pre>
 </div>
 
 <script>(function() {
-  kontra.init("game-canvas-0");
-  var canvas = document.querySelector("#game-canvas-0");
+  kontra.init("game-canvas-4");
+  var canvas = document.querySelector("#game-canvas-4");
   canvas.width = 600;
   canvas.height = 200;
   var context = canvas.getContext("2d");

--- a/docs/api/sprite.html
+++ b/docs/api/sprite.html
@@ -192,15 +192,6 @@
           <h2 id="toc"><a href="#toc" class="section-link">Table of Contents<span aria-hidden="true">#</span></a></h2>
 
           <ul aria-labelledby="toc">
-            <li>
-              <ul>
-                <li><a href="api/sprite#rectangle-sprite">Rectangle Sprite</a></li>
-                <li><a href="api/sprite#image-sprite">Image Sprite</a></li>
-                <li><a href="api/sprite#animation-sprite">Animation Sprite</a></li>
-                <li><a href="api/sprite#custom-properties">Custom Properties</a></li>
-                <li><a href="api/sprite#extending-a sprite">Extending a Sprite</a></li>
-              </ul>
-            </li>
 
             <li>
               <h3 id="properties">Properties</h3>
@@ -351,596 +342,6 @@
           </ul>
         </section>
 
-        <section>
-          <h2 id="rectangle-sprite">
-            <a href="#rectangle-sprite" class="section-link">
-              <span>Rectangle Sprite</span>
-              <span aria-hidden="true">#</span>
-            </a>
-          </h2>
-
-          <p>In its most basic form, a sprite is a rectangle with a fill color. To create a rectangle sprite, pass the arguments <code>width</code>, <code>height</code>, and <code>color</code>. A rectangle sprite is great for initial prototyping and particles.</p>
-<canvas id="game-canvas-0"></canvas>
-
-<div class="tablist">
-  <ul role="tablist">
-    <li role="presentation" data-tab="global">
-      <button role="tab" id="game-canvas-0-global-tab">Global Object</button>
-    </li>
-    <li role="presentation" data-tab="es">
-      <button role="tab" id="game-canvas-0-es-tab">ES Module Import</button>
-    </li>
-    <li role="presentation" data-tab="bundle">
-      <button role="tab" id="game-canvas-0-bundle-tab">Module Bundler</button>
-    </li>
-    <li role="presentation"></li>
-  </ul>
-  <section role="tabpanel" aria-labelledby=game-canvas-0-global-tab data-tabpanel="global">
-    <pre><code class="lang-js">let { Sprite } &#x3D; kontra
-
-let sprite &#x3D; Sprite({
-  x: 300,
-  y: 100,
-  anchor: {x: 0.5, y: 0.5},
-
-  // required for a rectangle sprite
-  width: 20,
-  height: 40,
-  color: &#x27;red&#x27;
-});
-
-sprite.render();</code></pre>
-  </section>
-  <section role="tabpanel" aria-labelledby=game-canvas-0-es-tab data-tabpanel="es">
-    <pre><code class="lang-js">import { Sprite } from &#x27;path/to/kontra.mjs&#x27;
-
-let sprite &#x3D; Sprite({
-  x: 300,
-  y: 100,
-  anchor: {x: 0.5, y: 0.5},
-
-  // required for a rectangle sprite
-  width: 20,
-  height: 40,
-  color: &#x27;red&#x27;
-});
-
-sprite.render();</code></pre>
-  </section>
-  <section role="tabpanel" aria-labelledby=game-canvas-0-bundle-tab data-tabpanel="bundle">
-    <pre><code class="lang-js">import { Sprite } from &#x27;kontra&#x27;;
-
-let sprite &#x3D; Sprite({
-  x: 300,
-  y: 100,
-  anchor: {x: 0.5, y: 0.5},
-
-  // required for a rectangle sprite
-  width: 20,
-  height: 40,
-  color: &#x27;red&#x27;
-});
-
-sprite.render();</code></pre>
-  </section>
-</div>
-
-<script>(function() {
-  kontra.init("game-canvas-0");
-  var canvas = document.querySelector("#game-canvas-0");
-  canvas.width = 600;
-  canvas.height = 200;
-  var context = canvas.getContext("2d");
-  // exclude-code:start
-let { Sprite } = kontra;
-// exclude-code:end
-let sprite = Sprite({
-  x: 300,
-  y: 100,
-  anchor: {x: 0.5, y: 0.5},
-
-  // required for a rectangle sprite
-  width: 20,
-  height: 40,
-  color: 'red'
-});
-// exclude-code:start
-sprite.context = context;
-// exclude-code:end
-
-sprite.render();
-})();</script>        </section>
-        <section>
-          <h2 id="image-sprite">
-            <a href="#image-sprite" class="section-link">
-              <span>Image Sprite</span>
-              <span aria-hidden="true">#</span>
-            </a>
-          </h2>
-
-          <p>A sprite can use an image instead of drawing a rectangle. To create an image sprite, pass the <code>image</code> argument. The size of the sprite will automatically be set as the width and height of the image.</p>
-<canvas id="game-canvas-1"></canvas>
-
-<div class="tablist">
-  <ul role="tablist">
-    <li role="presentation" data-tab="global">
-      <button role="tab" id="game-canvas-1-global-tab">Global Object</button>
-    </li>
-    <li role="presentation" data-tab="es">
-      <button role="tab" id="game-canvas-1-es-tab">ES Module Import</button>
-    </li>
-    <li role="presentation" data-tab="bundle">
-      <button role="tab" id="game-canvas-1-bundle-tab">Module Bundler</button>
-    </li>
-    <li role="presentation"></li>
-  </ul>
-  <section role="tabpanel" aria-labelledby=game-canvas-1-global-tab data-tabpanel="global">
-    <pre><code class="lang-js">let { Sprite } &#x3D; kontra
-
-let image &#x3D; new Image();
-image.src &#x3D; &#x27;assets/imgs/character.png&#x27;;
-image.onload &#x3D; function() {
-  let sprite &#x3D; Sprite({
-    x: 300,
-    y: 100,
-    anchor: {x: 0.5, y: 0.5},
-
-    // required for an image sprite
-    image: image
-  });
-
-  sprite.render();
-};</code></pre>
-  </section>
-  <section role="tabpanel" aria-labelledby=game-canvas-1-es-tab data-tabpanel="es">
-    <pre><code class="lang-js">import { Sprite } from &#x27;path/to/kontra.mjs&#x27;
-
-let image &#x3D; new Image();
-image.src &#x3D; &#x27;assets/imgs/character.png&#x27;;
-image.onload &#x3D; function() {
-  let sprite &#x3D; Sprite({
-    x: 300,
-    y: 100,
-    anchor: {x: 0.5, y: 0.5},
-
-    // required for an image sprite
-    image: image
-  });
-
-  sprite.render();
-};</code></pre>
-  </section>
-  <section role="tabpanel" aria-labelledby=game-canvas-1-bundle-tab data-tabpanel="bundle">
-    <pre><code class="lang-js">import { Sprite } from &#x27;kontra&#x27;;
-
-let image &#x3D; new Image();
-image.src &#x3D; &#x27;assets/imgs/character.png&#x27;;
-image.onload &#x3D; function() {
-  let sprite &#x3D; Sprite({
-    x: 300,
-    y: 100,
-    anchor: {x: 0.5, y: 0.5},
-
-    // required for an image sprite
-    image: image
-  });
-
-  sprite.render();
-};</code></pre>
-  </section>
-</div>
-
-<script>(function() {
-  kontra.init("game-canvas-1");
-  var canvas = document.querySelector("#game-canvas-1");
-  canvas.width = 600;
-  canvas.height = 200;
-  var context = canvas.getContext("2d");
-  // exclude-code:start
-let { Sprite } = kontra;
-// exclude-code:end
-let image = new Image();
-image.src = 'assets/imgs/character.png';
-image.onload = function() {
-  let sprite = Sprite({
-    x: 300,
-    y: 100,
-    anchor: {x: 0.5, y: 0.5},
-
-    // required for an image sprite
-    image: image
-  });
-  // exclude-code:start
-  sprite.context = context;
-  // exclude-code:end
-
-  sprite.render();
-};
-})();</script>        </section>
-        <section>
-          <h2 id="animation-sprite">
-            <a href="#animation-sprite" class="section-link">
-              <span>Animation Sprite</span>
-              <span aria-hidden="true">#</span>
-            </a>
-          </h2>
-
-          <p>A sprite can use a spritesheet animation as well. To create an animation sprite, pass the <code>animations</code> argument. The size of the sprite will automatically be set as the width and height of a frame of the spritesheet.</p>
-<p>A sprite can have multiple named animations. The easiest way to create animations is to use <a href="SpriteSheet">SpriteSheet</a>. All animations will automatically be <a href="animation#clone">cloned</a> so no two sprites update the same animation.</p>
-<canvas id="game-canvas-2"></canvas>
-
-<div class="tablist">
-  <ul role="tablist">
-    <li role="presentation" data-tab="global">
-      <button role="tab" id="game-canvas-2-global-tab">Global Object</button>
-    </li>
-    <li role="presentation" data-tab="es">
-      <button role="tab" id="game-canvas-2-es-tab">ES Module Import</button>
-    </li>
-    <li role="presentation" data-tab="bundle">
-      <button role="tab" id="game-canvas-2-bundle-tab">Module Bundler</button>
-    </li>
-    <li role="presentation"></li>
-  </ul>
-  <section role="tabpanel" aria-labelledby=game-canvas-2-global-tab data-tabpanel="global">
-    <pre><code class="lang-js">let { Sprite, SpriteSheet, GameLoop } &#x3D; kontra
-
-let image &#x3D; new Image();
-image.src &#x3D; &#x27;assets/imgs/character_walk_sheet.png&#x27;;
-image.onload &#x3D; function() {
-
-  // use spriteSheet to create animations from an image
-  let spriteSheet &#x3D; SpriteSheet({
-    image: image,
-    frameWidth: 72,
-    frameHeight: 97,
-    animations: {
-      // create a named animation: walk
-      walk: {
-        frames: &#x27;0..9&#x27;,  // frames 0 through 9
-        frameRate: 30
-      }
-    }
-  });
-
-  let sprite &#x3D; Sprite({
-    x: 300,
-    y: 100,
-    anchor: {x: 0.5, y: 0.5},
-
-    // required for an animation sprite
-    animations: spriteSheet.animations
-  });
-
-  // use kontra.gameLoop to play the animation
-  let loop &#x3D; GameLoop({
-    update: function(dt) {
-      sprite.update();
-    },
-    render: function() {
-      sprite.render();
-    }
-  });
-
-  loop.start();
-};</code></pre>
-  </section>
-  <section role="tabpanel" aria-labelledby=game-canvas-2-es-tab data-tabpanel="es">
-    <pre><code class="lang-js">import { Sprite, SpriteSheet, GameLoop } from &#x27;path/to/kontra.mjs&#x27;
-
-let image &#x3D; new Image();
-image.src &#x3D; &#x27;assets/imgs/character_walk_sheet.png&#x27;;
-image.onload &#x3D; function() {
-
-  // use spriteSheet to create animations from an image
-  let spriteSheet &#x3D; SpriteSheet({
-    image: image,
-    frameWidth: 72,
-    frameHeight: 97,
-    animations: {
-      // create a named animation: walk
-      walk: {
-        frames: &#x27;0..9&#x27;,  // frames 0 through 9
-        frameRate: 30
-      }
-    }
-  });
-
-  let sprite &#x3D; Sprite({
-    x: 300,
-    y: 100,
-    anchor: {x: 0.5, y: 0.5},
-
-    // required for an animation sprite
-    animations: spriteSheet.animations
-  });
-
-  // use kontra.gameLoop to play the animation
-  let loop &#x3D; GameLoop({
-    update: function(dt) {
-      sprite.update();
-    },
-    render: function() {
-      sprite.render();
-    }
-  });
-
-  loop.start();
-};</code></pre>
-  </section>
-  <section role="tabpanel" aria-labelledby=game-canvas-2-bundle-tab data-tabpanel="bundle">
-    <pre><code class="lang-js">import { Sprite, SpriteSheet, GameLoop } from &#x27;kontra&#x27;;
-
-let image &#x3D; new Image();
-image.src &#x3D; &#x27;assets/imgs/character_walk_sheet.png&#x27;;
-image.onload &#x3D; function() {
-
-  // use spriteSheet to create animations from an image
-  let spriteSheet &#x3D; SpriteSheet({
-    image: image,
-    frameWidth: 72,
-    frameHeight: 97,
-    animations: {
-      // create a named animation: walk
-      walk: {
-        frames: &#x27;0..9&#x27;,  // frames 0 through 9
-        frameRate: 30
-      }
-    }
-  });
-
-  let sprite &#x3D; Sprite({
-    x: 300,
-    y: 100,
-    anchor: {x: 0.5, y: 0.5},
-
-    // required for an animation sprite
-    animations: spriteSheet.animations
-  });
-
-  // use kontra.gameLoop to play the animation
-  let loop &#x3D; GameLoop({
-    update: function(dt) {
-      sprite.update();
-    },
-    render: function() {
-      sprite.render();
-    }
-  });
-
-  loop.start();
-};</code></pre>
-  </section>
-</div>
-
-<script>(function() {
-  kontra.init("game-canvas-2");
-  var canvas = document.querySelector("#game-canvas-2");
-  canvas.width = 600;
-  canvas.height = 200;
-  var context = canvas.getContext("2d");
-  // exclude-code:start
-let { Sprite, SpriteSheet, GameLoop } = kontra;
-// exclude-code:end
-let image = new Image();
-image.src = 'assets/imgs/character_walk_sheet.png';
-image.onload = function() {
-
-  // use spriteSheet to create animations from an image
-  let spriteSheet = SpriteSheet({
-    image: image,
-    frameWidth: 72,
-    frameHeight: 97,
-    animations: {
-      // create a named animation: walk
-      walk: {
-        frames: '0..9',  // frames 0 through 9
-        frameRate: 30
-      }
-    }
-  });
-
-  let sprite = Sprite({
-    x: 300,
-    y: 100,
-    anchor: {x: 0.5, y: 0.5},
-
-    // required for an animation sprite
-    animations: spriteSheet.animations
-  });
-  // exclude-code:start
-  sprite.context = context;
-  // exclude-code:end
-
-  // use kontra.gameLoop to play the animation
-  let loop = GameLoop({
-  // exclude-code:start
-  clearCanvas: false,
-  // exclude-code:end
-    update: function(dt) {
-      sprite.update();
-    },
-    render: function() {
-      // exclude-code:start
-      context.clearRect(0,0,context.canvas.width,context.canvas.height);
-      // exclude-code:end
-      sprite.render();
-    }
-  });
-
-  loop.start();
-};
-})();</script>        </section>
-        <section>
-          <h2 id="custom-properties">
-            <a href="#custom-properties" class="section-link">
-              <span>Custom Properties</span>
-              <span aria-hidden="true">#</span>
-            </a>
-          </h2>
-
-          <p>If you need to draw a different shape, such as a circle, you can pass in custom properties and a render function to handle drawing the sprite.</p>
-<canvas id="game-canvas-3"></canvas>
-
-<div class="tablist">
-  <ul role="tablist">
-    <li role="presentation" data-tab="global">
-      <button role="tab" id="game-canvas-3-global-tab">Global Object</button>
-    </li>
-    <li role="presentation" data-tab="es">
-      <button role="tab" id="game-canvas-3-es-tab">ES Module Import</button>
-    </li>
-    <li role="presentation" data-tab="bundle">
-      <button role="tab" id="game-canvas-3-bundle-tab">Module Bundler</button>
-    </li>
-    <li role="presentation"></li>
-  </ul>
-  <section role="tabpanel" aria-labelledby=game-canvas-3-global-tab data-tabpanel="global">
-    <pre><code class="lang-js">let { Sprite } &#x3D; kontra
-
-let sprite &#x3D; Sprite({
-  x: 300,
-  y: 100,
-
-  color: &#x27;red&#x27;,
-
-  // custom properties
-  radius: 20,
-
-  render: function() {
-    this.context.fillStyle &#x3D; this.color;
-
-    this.context.beginPath();
-    this.context.arc(this.x, this.y, this.radius, 0, 2  * Math.PI);
-    this.context.fill();
-  }
-});
-
-sprite.render();</code></pre>
-  </section>
-  <section role="tabpanel" aria-labelledby=game-canvas-3-es-tab data-tabpanel="es">
-    <pre><code class="lang-js">import { Sprite } from &#x27;path/to/kontra.mjs&#x27;
-
-let sprite &#x3D; Sprite({
-  x: 300,
-  y: 100,
-
-  color: &#x27;red&#x27;,
-
-  // custom properties
-  radius: 20,
-
-  render: function() {
-    this.context.fillStyle &#x3D; this.color;
-
-    this.context.beginPath();
-    this.context.arc(this.x, this.y, this.radius, 0, 2  * Math.PI);
-    this.context.fill();
-  }
-});
-
-sprite.render();</code></pre>
-  </section>
-  <section role="tabpanel" aria-labelledby=game-canvas-3-bundle-tab data-tabpanel="bundle">
-    <pre><code class="lang-js">import { Sprite } from &#x27;kontra&#x27;;
-
-let sprite &#x3D; Sprite({
-  x: 300,
-  y: 100,
-
-  color: &#x27;red&#x27;,
-
-  // custom properties
-  radius: 20,
-
-  render: function() {
-    this.context.fillStyle &#x3D; this.color;
-
-    this.context.beginPath();
-    this.context.arc(this.x, this.y, this.radius, 0, 2  * Math.PI);
-    this.context.fill();
-  }
-});
-
-sprite.render();</code></pre>
-  </section>
-</div>
-
-<script>(function() {
-  kontra.init("game-canvas-3");
-  var canvas = document.querySelector("#game-canvas-3");
-  canvas.width = 600;
-  canvas.height = 200;
-  var context = canvas.getContext("2d");
-  // exclude-code:start
-let { Sprite } = kontra;
-// exclude-code:end
-let sprite = Sprite({
-  x: 300,
-  y: 100,
-
-  color: 'red',
-
-  // custom properties
-  radius: 20,
-
-  render: function() {
-    this.context.fillStyle = this.color;
-
-    this.context.beginPath();
-    this.context.arc(this.x, this.y, this.radius, 0, 2  * Math.PI);
-    this.context.fill();
-  }
-});
-// exclude-code:start
-sprite.context = context;
-// exclude-code:end
-
-sprite.render();
-})();</script>        </section>
-        <section>
-          <h2 id="extending-a sprite">
-            <a href="#extending-a sprite" class="section-link">
-              <span>Extending a Sprite</span>
-              <span aria-hidden="true">#</span>
-            </a>
-          </h2>
-
-          <p>If you want to extend a Sprite, you can do so by extending the Sprite class. The one caveat is that <code>Sprite</code> is not the Sprite class, but actually is a factory function.</p>
-<p>To extend the Sprite class, use the <code>.class</code> property of the constructor.</p>
-<div class="tablist">
-  <ul role="tablist">
-    <li role="presentation" data-tab="global">
-      <button role="tab" id="extending-a-sprite-global-tab">Global Object</button>
-    </li>
-    <li role="presentation" data-tab="es">
-      <button role="tab" id="extending-a-sprite-es-tab">ES Module Import</button>
-    </li>
-    <li role="presentation" data-tab="bundle">
-      <button role="tab" id="extending-a-sprite-bundle-tab">Module Bundler</button>
-    </li>
-    <li role="presentation"></li>
-  </ul>
-  <section role="tabpanel" aria-labelledby=extending-a-sprite-global-tab data-tabpanel="global"><pre><code class="lang-js">let { Sprite } = kontra;
-
-class CustomSprite extends Sprite.class {
-  // ...
-}
-</code></pre></section>
-  <section role="tabpanel" aria-labelledby=extending-a-sprite-es-tab data-tabpanel="es"><pre><code class="lang-js">import { Sprite } from 'path/to/kontra.mjs';
-
-class CustomSprite extends Sprite.class {
-  // ...
-}
-</code></pre></section>
-  <section role="tabpanel" aria-labelledby=extending-a-sprite-bundle-tab data-tabpanel="bundle"><pre><code class="lang-js">import { Sprite } from &#39;kontra&#39;;
-
-class CustomSprite extends Sprite.class {
-  // ...
-}
-</code></pre></section>
-</div>
-        </section>
 
         <section>
           <h2 id="acceleration">
@@ -976,7 +377,7 @@ class CustomSprite extends Sprite.class {
     </li>
     <li role="presentation"></li>
   </ul>
-  <section role="tabpanel" aria-labelledby=advance-global-tab data-tabpanel="global"><pre><code class="lang-js">let { Sprite } = kontra;
+  <section role="tabpanel" aria-labelledby=advance-global-tab data-tabpanel="global"><pre><code class="language-js">let { Sprite } = kontra;
 
 let sprite = Sprite({
   x: 100,
@@ -999,9 +400,8 @@ let sprite = Sprite({
       this.dy = -this.dy;
     }
   }
-});
-</code></pre></section>
-  <section role="tabpanel" aria-labelledby=advance-es-tab data-tabpanel="es"><pre><code class="lang-js">import { Sprite } from 'path/to/kontra.mjs';
+});</code></pre></section>
+  <section role="tabpanel" aria-labelledby=advance-es-tab data-tabpanel="es"><pre><code class="language-js">import { Sprite } from 'path/to/kontra.mjs';
 
 let sprite = Sprite({
   x: 100,
@@ -1024,9 +424,8 @@ let sprite = Sprite({
       this.dy = -this.dy;
     }
   }
-});
-</code></pre></section>
-  <section role="tabpanel" aria-labelledby=advance-bundle-tab data-tabpanel="bundle"><pre><code class="lang-js">import { Sprite } from &#39;kontra&#39;;
+});</code></pre></section>
+  <section role="tabpanel" aria-labelledby=advance-bundle-tab data-tabpanel="bundle"><pre><code class="language-js">import { Sprite } from &#39;kontra&#39;;
 
 let sprite = Sprite({
   x: 100,
@@ -1049,8 +448,7 @@ let sprite = Sprite({
       this.dy = -this.dy;
     }
   }
-});
-</code></pre></section>
+});</code></pre></section>
 </div>
           <h3 id="title-advance"><span class="visually-hidden">advance</span> Parameters</span></h3>
           <dl aria-labelledby="title-advance">
@@ -1072,22 +470,22 @@ let sprite = Sprite({
           </h2>
 
           <p>The x and y origin of the sprite. {x:0, y:0} is the top left corner of the sprite, {x:1, y:1} is the bottom right corner.</p>
-<canvas id="game-canvas-4"></canvas>
+<canvas id="game-canvas-0"></canvas>
 
 <div class="tablist">
   <ul role="tablist">
     <li role="presentation" data-tab="global">
-      <button role="tab" id="game-canvas-4-global-tab">Global Object</button>
+      <button role="tab" id="game-canvas-0-global-tab">Global Object</button>
     </li>
     <li role="presentation" data-tab="es">
-      <button role="tab" id="game-canvas-4-es-tab">ES Module Import</button>
+      <button role="tab" id="game-canvas-0-es-tab">ES Module Import</button>
     </li>
     <li role="presentation" data-tab="bundle">
-      <button role="tab" id="game-canvas-4-bundle-tab">Module Bundler</button>
+      <button role="tab" id="game-canvas-0-bundle-tab">Module Bundler</button>
     </li>
     <li role="presentation"></li>
   </ul>
-  <section role="tabpanel" aria-labelledby=game-canvas-4-global-tab data-tabpanel="global">
+  <section role="tabpanel" aria-labelledby=game-canvas-0-global-tab data-tabpanel="global">
     <pre><code class="lang-js">let { Sprite } &#x3D; kontra
 
 let sprite &#x3D; Sprite({
@@ -1116,7 +514,7 @@ sprite.anchor &#x3D; {x: 1, y: 1};
 sprite.x &#x3D; 450;
 sprite.render();</code></pre>
   </section>
-  <section role="tabpanel" aria-labelledby=game-canvas-4-es-tab data-tabpanel="es">
+  <section role="tabpanel" aria-labelledby=game-canvas-0-es-tab data-tabpanel="es">
     <pre><code class="lang-js">import { Sprite } from &#x27;path/to/kontra.mjs&#x27;
 
 let sprite &#x3D; Sprite({
@@ -1145,7 +543,7 @@ sprite.anchor &#x3D; {x: 1, y: 1};
 sprite.x &#x3D; 450;
 sprite.render();</code></pre>
   </section>
-  <section role="tabpanel" aria-labelledby=game-canvas-4-bundle-tab data-tabpanel="bundle">
+  <section role="tabpanel" aria-labelledby=game-canvas-0-bundle-tab data-tabpanel="bundle">
     <pre><code class="lang-js">import { Sprite } from &#x27;kontra&#x27;;
 
 let sprite &#x3D; Sprite({
@@ -1177,8 +575,8 @@ sprite.render();</code></pre>
 </div>
 
 <script>(function() {
-  kontra.init("game-canvas-4");
-  var canvas = document.querySelector("#game-canvas-4");
+  kontra.init("game-canvas-0");
+  var canvas = document.querySelector("#game-canvas-0");
   canvas.width = 600;
   canvas.height = 200;
   var context = canvas.getContext("2d");
@@ -1237,7 +635,7 @@ sprite.render();
     </li>
     <li role="presentation"></li>
   </ul>
-  <section role="tabpanel" aria-labelledby=animations-global-tab data-tabpanel="global"><pre><code class="lang-js">let { Sprite, SpriteSheet } = kontra;
+  <section role="tabpanel" aria-labelledby=animations-global-tab data-tabpanel="global"><pre><code class="language-js">let { Sprite, SpriteSheet } = kontra;
 
 let spriteSheet = SpriteSheet({
   // ...
@@ -1258,9 +656,8 @@ let sprite = Sprite({
   animations: spriteSheet.animations
 });
 
-sprite.playAnimation(&#39;idle&#39;);
-</code></pre></section>
-  <section role="tabpanel" aria-labelledby=animations-es-tab data-tabpanel="es"><pre><code class="lang-js">import { Sprite, SpriteSheet } from 'path/to/kontra.mjs';
+sprite.playAnimation(&#39;idle&#39;);</code></pre></section>
+  <section role="tabpanel" aria-labelledby=animations-es-tab data-tabpanel="es"><pre><code class="language-js">import { Sprite, SpriteSheet } from 'path/to/kontra.mjs';
 
 let spriteSheet = SpriteSheet({
   // ...
@@ -1281,9 +678,8 @@ let sprite = Sprite({
   animations: spriteSheet.animations
 });
 
-sprite.playAnimation(&#39;idle&#39;);
-</code></pre></section>
-  <section role="tabpanel" aria-labelledby=animations-bundle-tab data-tabpanel="bundle"><pre><code class="lang-js">import { Sprite, SpriteSheet } from &#39;kontra&#39;;
+sprite.playAnimation(&#39;idle&#39;);</code></pre></section>
+  <section role="tabpanel" aria-labelledby=animations-bundle-tab data-tabpanel="bundle"><pre><code class="language-js">import { Sprite, SpriteSheet } from &#39;kontra&#39;;
 
 let spriteSheet = SpriteSheet({
   // ...
@@ -1304,8 +700,7 @@ let sprite = Sprite({
   animations: spriteSheet.animations
 });
 
-sprite.playAnimation(&#39;idle&#39;);
-</code></pre></section>
+sprite.playAnimation(&#39;idle&#39;);</code></pre></section>
 </div>
           
         </section>
@@ -1332,7 +727,7 @@ sprite.playAnimation(&#39;idle&#39;);
     </li>
     <li role="presentation"></li>
   </ul>
-  <section role="tabpanel" aria-labelledby=collideswith-global-tab data-tabpanel="global"><pre><code class="lang-js">let { Sprite } = kontra;
+  <section role="tabpanel" aria-labelledby=collideswith-global-tab data-tabpanel="global"><pre><code class="language-js">let { Sprite } = kontra;
 
 let sprite = Sprite({
   x: 100,
@@ -1352,9 +747,8 @@ sprite.collidesWith(sprite2);  //=&gt; false
 
 sprite2.x = 115;
 
-sprite.collidesWith(sprite2);  //=&gt; true
-</code></pre></section>
-  <section role="tabpanel" aria-labelledby=collideswith-es-tab data-tabpanel="es"><pre><code class="lang-js">import { Sprite } from 'path/to/kontra.mjs';
+sprite.collidesWith(sprite2);  //=&gt; true</code></pre></section>
+  <section role="tabpanel" aria-labelledby=collideswith-es-tab data-tabpanel="es"><pre><code class="language-js">import { Sprite } from 'path/to/kontra.mjs';
 
 let sprite = Sprite({
   x: 100,
@@ -1374,9 +768,8 @@ sprite.collidesWith(sprite2);  //=&gt; false
 
 sprite2.x = 115;
 
-sprite.collidesWith(sprite2);  //=&gt; true
-</code></pre></section>
-  <section role="tabpanel" aria-labelledby=collideswith-bundle-tab data-tabpanel="bundle"><pre><code class="lang-js">import { Sprite } from &#39;kontra&#39;;
+sprite.collidesWith(sprite2);  //=&gt; true</code></pre></section>
+  <section role="tabpanel" aria-labelledby=collideswith-bundle-tab data-tabpanel="bundle"><pre><code class="language-js">import { Sprite } from &#39;kontra&#39;;
 
 let sprite = Sprite({
   x: 100,
@@ -1396,8 +789,7 @@ sprite.collidesWith(sprite2);  //=&gt; false
 
 sprite2.x = 115;
 
-sprite.collidesWith(sprite2);  //=&gt; true
-</code></pre></section>
+sprite.collidesWith(sprite2);  //=&gt; true</code></pre></section>
 </div>
 <p>If you need a different type of collision check, you can override this function by passing an argument by the same name.</p>
 <div class="tablist">
@@ -1413,7 +805,7 @@ sprite.collidesWith(sprite2);  //=&gt; true
     </li>
     <li role="presentation"></li>
   </ul>
-  <section role="tabpanel" aria-labelledby=collideswith-global-tab data-tabpanel="global"><pre><code class="lang-js">// circle collision
+  <section role="tabpanel" aria-labelledby=collideswith-global-tab data-tabpanel="global"><pre><code class="language-js">// circle collision
 function collidesWith(object) {
   let dx = this.x - object.x;
   let dy = this.y - object.y;
@@ -1436,9 +828,8 @@ let sprite2 = Sprite({
   collidesWith: collidesWith
 });
 
-sprite.collidesWith(sprite2);  //=&gt; true
-</code></pre></section>
-  <section role="tabpanel" aria-labelledby=collideswith-es-tab data-tabpanel="es"><pre><code class="lang-js">// circle collision
+sprite.collidesWith(sprite2);  //=&gt; true</code></pre></section>
+  <section role="tabpanel" aria-labelledby=collideswith-es-tab data-tabpanel="es"><pre><code class="language-js">// circle collision
 function collidesWith(object) {
   let dx = this.x - object.x;
   let dy = this.y - object.y;
@@ -1461,9 +852,8 @@ let sprite2 = Sprite({
   collidesWith: collidesWith
 });
 
-sprite.collidesWith(sprite2);  //=&gt; true
-</code></pre></section>
-  <section role="tabpanel" aria-labelledby=collideswith-bundle-tab data-tabpanel="bundle"><pre><code class="lang-js">// circle collision
+sprite.collidesWith(sprite2);  //=&gt; true</code></pre></section>
+  <section role="tabpanel" aria-labelledby=collideswith-bundle-tab data-tabpanel="bundle"><pre><code class="language-js">// circle collision
 function collidesWith(object) {
   let dx = this.x - object.x;
   let dy = this.y - object.y;
@@ -1486,8 +876,7 @@ let sprite2 = Sprite({
   collidesWith: collidesWith
 });
 
-sprite.collidesWith(sprite2);  //=&gt; true
-</code></pre></section>
+sprite.collidesWith(sprite2);  //=&gt; true</code></pre></section>
 </div>
           <h3 id="title-collidesWith"><span class="visually-hidden">collidesWith</span> Parameters</span></h3>
           <dl aria-labelledby="title-collidesWith">
@@ -1581,7 +970,7 @@ sprite.collidesWith(sprite2);  //=&gt; true
     </li>
     <li role="presentation"></li>
   </ul>
-  <section role="tabpanel" aria-labelledby=draw-global-tab data-tabpanel="global"><pre><code class="lang-js">let { Sprite } = kontra;
+  <section role="tabpanel" aria-labelledby=draw-global-tab data-tabpanel="global"><pre><code class="language-js">let { Sprite } = kontra;
 
 let sprite = Sprite({
  x: 290,
@@ -1601,9 +990,8 @@ let sprite = Sprite({
  }
 });
 
-sprite.render();
-</code></pre></section>
-  <section role="tabpanel" aria-labelledby=draw-es-tab data-tabpanel="es"><pre><code class="lang-js">import { Sprite } from 'path/to/kontra.mjs';
+sprite.render();</code></pre></section>
+  <section role="tabpanel" aria-labelledby=draw-es-tab data-tabpanel="es"><pre><code class="language-js">import { Sprite } from 'path/to/kontra.mjs';
 
 let sprite = Sprite({
  x: 290,
@@ -1623,9 +1011,8 @@ let sprite = Sprite({
  }
 });
 
-sprite.render();
-</code></pre></section>
-  <section role="tabpanel" aria-labelledby=draw-bundle-tab data-tabpanel="bundle"><pre><code class="lang-js">import { Sprite } from &#39;kontra&#39;;
+sprite.render();</code></pre></section>
+  <section role="tabpanel" aria-labelledby=draw-bundle-tab data-tabpanel="bundle"><pre><code class="language-js">import { Sprite } from &#39;kontra&#39;;
 
 let sprite = Sprite({
  x: 290,
@@ -1645,8 +1032,7 @@ let sprite = Sprite({
  }
 });
 
-sprite.render();
-</code></pre></section>
+sprite.render();</code></pre></section>
 </div>
           
         </section>
@@ -1750,7 +1136,7 @@ sprite.render();
     </li>
     <li role="presentation"></li>
   </ul>
-  <section role="tabpanel" aria-labelledby=playanimation-global-tab data-tabpanel="global"><pre><code class="lang-js">let { Sprite, SpriteSheet } = kontra;
+  <section role="tabpanel" aria-labelledby=playanimation-global-tab data-tabpanel="global"><pre><code class="language-js">let { Sprite, SpriteSheet } = kontra;
 
 let spriteSheet = SpriteSheet({
   // ...
@@ -1770,9 +1156,8 @@ let sprite = Sprite({
   animations: spriteSheet.animations
 });
 
-sprite.playAnimation(&#39;idle&#39;);
-</code></pre></section>
-  <section role="tabpanel" aria-labelledby=playanimation-es-tab data-tabpanel="es"><pre><code class="lang-js">import { Sprite, SpriteSheet } from 'path/to/kontra.mjs';
+sprite.playAnimation(&#39;idle&#39;);</code></pre></section>
+  <section role="tabpanel" aria-labelledby=playanimation-es-tab data-tabpanel="es"><pre><code class="language-js">import { Sprite, SpriteSheet } from 'path/to/kontra.mjs';
 
 let spriteSheet = SpriteSheet({
   // ...
@@ -1792,9 +1177,8 @@ let sprite = Sprite({
   animations: spriteSheet.animations
 });
 
-sprite.playAnimation(&#39;idle&#39;);
-</code></pre></section>
-  <section role="tabpanel" aria-labelledby=playanimation-bundle-tab data-tabpanel="bundle"><pre><code class="lang-js">import { Sprite, SpriteSheet } from &#39;kontra&#39;;
+sprite.playAnimation(&#39;idle&#39;);</code></pre></section>
+  <section role="tabpanel" aria-labelledby=playanimation-bundle-tab data-tabpanel="bundle"><pre><code class="language-js">import { Sprite, SpriteSheet } from &#39;kontra&#39;;
 
 let spriteSheet = SpriteSheet({
   // ...
@@ -1814,8 +1198,7 @@ let sprite = Sprite({
   animations: spriteSheet.animations
 });
 
-sprite.playAnimation(&#39;idle&#39;);
-</code></pre></section>
+sprite.playAnimation(&#39;idle&#39;);</code></pre></section>
 </div>
           <h3 id="title-playAnimation"><span class="visually-hidden">playAnimation</span> Parameters</span></h3>
           <dl aria-labelledby="title-playAnimation">

--- a/docs/api/spriteSheet.html
+++ b/docs/api/spriteSheet.html
@@ -90,7 +90,7 @@
     </li>
     <li role="presentation"></li>
   </ul>
-  <section role="tabpanel" aria-labelledby=spritesheet-global-tab data-tabpanel="global"><pre><code class="lang-js">let { Sprite, SpriteSheet } = kontra;
+  <section role="tabpanel" aria-labelledby=spritesheet-global-tab data-tabpanel="global"><pre><code class="language-js">let { Sprite, SpriteSheet } = kontra;
 
 let image = new Image();
 image.src = &#39;assets/imgs/character_walk_sheet.png&#39;;
@@ -115,9 +115,8 @@ image.onload = function() {
     // use the sprite sheet animations for the sprite
     animations: spriteSheet.animations
   });
-};
-</code></pre></section>
-  <section role="tabpanel" aria-labelledby=spritesheet-es-tab data-tabpanel="es"><pre><code class="lang-js">import { Sprite, SpriteSheet } from 'path/to/kontra.mjs';
+};</code></pre></section>
+  <section role="tabpanel" aria-labelledby=spritesheet-es-tab data-tabpanel="es"><pre><code class="language-js">import { Sprite, SpriteSheet } from 'path/to/kontra.mjs';
 
 let image = new Image();
 image.src = &#39;assets/imgs/character_walk_sheet.png&#39;;
@@ -142,9 +141,8 @@ image.onload = function() {
     // use the sprite sheet animations for the sprite
     animations: spriteSheet.animations
   });
-};
-</code></pre></section>
-  <section role="tabpanel" aria-labelledby=spritesheet-bundle-tab data-tabpanel="bundle"><pre><code class="lang-js">import { Sprite, SpriteSheet } from &#39;kontra&#39;;
+};</code></pre></section>
+  <section role="tabpanel" aria-labelledby=spritesheet-bundle-tab data-tabpanel="bundle"><pre><code class="language-js">import { Sprite, SpriteSheet } from &#39;kontra&#39;;
 
 let image = new Image();
 image.src = &#39;assets/imgs/character_walk_sheet.png&#39;;
@@ -169,8 +167,7 @@ image.onload = function() {
     // use the sprite sheet animations for the sprite
     animations: spriteSheet.animations
   });
-};
-</code></pre></section>
+};</code></pre></section>
 </div>
         <h3 id="title-SpriteSheet"><span class="visually-hidden">SpriteSheet</span> Parameters</span></h3>
         <dl aria-labelledby="title-SpriteSheet">
@@ -287,7 +284,7 @@ image.onload = function() {
     </li>
     <li role="presentation"></li>
   </ul>
-  <section role="tabpanel" aria-labelledby=createanimations-global-tab data-tabpanel="global"><pre><code class="lang-js">let { Sprite, SpriteSheet } = kontra;
+  <section role="tabpanel" aria-labelledby=createanimations-global-tab data-tabpanel="global"><pre><code class="language-js">let { Sprite, SpriteSheet } = kontra;
 
 let image = new Image();
 image.src = &#39;assets/imgs/character_walk_sheet.png&#39;;
@@ -333,9 +330,8 @@ image.onload = function() {
       loop: false,
     }
   });
-};
-</code></pre></section>
-  <section role="tabpanel" aria-labelledby=createanimations-es-tab data-tabpanel="es"><pre><code class="lang-js">import { Sprite, SpriteSheet } from 'path/to/kontra.mjs';
+};</code></pre></section>
+  <section role="tabpanel" aria-labelledby=createanimations-es-tab data-tabpanel="es"><pre><code class="language-js">import { Sprite, SpriteSheet } from 'path/to/kontra.mjs';
 
 let image = new Image();
 image.src = &#39;assets/imgs/character_walk_sheet.png&#39;;
@@ -381,9 +377,8 @@ image.onload = function() {
       loop: false,
     }
   });
-};
-</code></pre></section>
-  <section role="tabpanel" aria-labelledby=createanimations-bundle-tab data-tabpanel="bundle"><pre><code class="lang-js">import { Sprite, SpriteSheet } from &#39;kontra&#39;;
+};</code></pre></section>
+  <section role="tabpanel" aria-labelledby=createanimations-bundle-tab data-tabpanel="bundle"><pre><code class="language-js">import { Sprite, SpriteSheet } from &#39;kontra&#39;;
 
 let image = new Image();
 image.src = &#39;assets/imgs/character_walk_sheet.png&#39;;
@@ -429,8 +424,7 @@ image.onload = function() {
       loop: false,
     }
   });
-};
-</code></pre></section>
+};</code></pre></section>
 </div>
           <h3 id="title-createAnimations"><span class="visually-hidden">createAnimations</span> Parameters</span></h3>
           <dl aria-labelledby="title-createAnimations">

--- a/docs/api/store.html
+++ b/docs/api/store.html
@@ -82,21 +82,18 @@
     </li>
     <li role="presentation"></li>
   </ul>
-  <section role="tabpanel" aria-labelledby=store-global-tab data-tabpanel="global"><pre><code class="lang-js">let { setStoreItem, getStoreItem } = kontra;
+  <section role="tabpanel" aria-labelledby=store-global-tab data-tabpanel="global"><pre><code class="language-js">let { setStoreItem, getStoreItem } = kontra;
 
 setStoreItem(&#39;highScore&#39;, 100);
-getStoreItem(&#39;highScore&#39;);  //=&gt; 100
-</code></pre></section>
-  <section role="tabpanel" aria-labelledby=store-es-tab data-tabpanel="es"><pre><code class="lang-js">import { setStoreItem, getStoreItem } from 'path/to/kontra.mjs';
+getStoreItem(&#39;highScore&#39;);  //=&gt; 100</code></pre></section>
+  <section role="tabpanel" aria-labelledby=store-es-tab data-tabpanel="es"><pre><code class="language-js">import { setStoreItem, getStoreItem } from 'path/to/kontra.mjs';
 
 setStoreItem(&#39;highScore&#39;, 100);
-getStoreItem(&#39;highScore&#39;);  //=&gt; 100
-</code></pre></section>
-  <section role="tabpanel" aria-labelledby=store-bundle-tab data-tabpanel="bundle"><pre><code class="lang-js">import { setStoreItem, getStoreItem } from &#39;kontra&#39;;
+getStoreItem(&#39;highScore&#39;);  //=&gt; 100</code></pre></section>
+  <section role="tabpanel" aria-labelledby=store-bundle-tab data-tabpanel="bundle"><pre><code class="language-js">import { setStoreItem, getStoreItem } from &#39;kontra&#39;;
 
 setStoreItem(&#39;highScore&#39;, 100);
-getStoreItem(&#39;highScore&#39;);  //=&gt; 100
-</code></pre></section>
+getStoreItem(&#39;highScore&#39;);  //=&gt; 100</code></pre></section>
 </div>
         
 

--- a/docs/api/tileEngine.html
+++ b/docs/api/tileEngine.html
@@ -198,6 +198,13 @@
           <h2 id="toc"><a href="#toc" class="section-link">Table of Contents<span aria-hidden="true">#</span></a></h2>
 
           <ul aria-labelledby="toc">
+            <li>
+              <ul>
+                <li><a href="api/tileEngine#basic-use">Basic Use</a></li>
+                <li><a href="api/tileEngine#advance-use">Advance Use</a></li>
+                <li><a href="api/tileEngine#moving-the camera">Moving the Camera</a></li>
+              </ul>
+            </li>
 
             <li>
               <h3 id="properties">Properties</h3>
@@ -293,6 +300,410 @@
           </ul>
         </section>
 
+        <section>
+          <h2 id="basic-use">
+            <a href="#basic-use" class="section-link">
+              <span>Basic Use</span>
+              <span aria-hidden="true">#</span>
+            </a>
+          </h2>
+
+          <p>Creating a tile map requires three things:</p>
+<ol>
+<li>Dimensions of the tile map and a tile</li>
+<li>At least one tileset with an image</li>
+<li>At least one layer with data</li>
+</ol>
+<p>To set up the tile engine, you&#39;ll need to pass it the width and height of a tile (in pixels) and the width and height of the map (in number of tiles).</p>
+<p>You&#39;ll then need to add at least one tileset with an image as well as firstgid, or first tile index of the tileset. The first tileset will always have a firstgid of 1 as 0 represents an empty tile.</p>
+<p>Lastly, you&#39;ll need to add at least one named layer with data. A layer tells the tile engine which tiles from the tileset image to use at what position on the map.</p>
+<p>Once all tileset images and all layers have been added, you can render the tile engine by calling its <a href="#render">render()</a> function.</p>
+<canvas id="game-canvas-5"></canvas>
+
+<div class="tablist">
+  <ul role="tablist">
+    <li role="presentation" data-tab="global">
+      <button role="tab" id="game-canvas-5-global-tab">Global Object</button>
+    </li>
+    <li role="presentation" data-tab="es">
+      <button role="tab" id="game-canvas-5-es-tab">ES Module Import</button>
+    </li>
+    <li role="presentation" data-tab="bundle">
+      <button role="tab" id="game-canvas-5-bundle-tab">Module Bundler</button>
+    </li>
+    <li role="presentation"></li>
+  </ul>
+  <section role="tabpanel" aria-labelledby=game-canvas-5-global-tab data-tabpanel="global">
+    <pre><code class="lang-js">let { TileEngine } &#x3D; kontra
+
+let img &#x3D; new Image();
+img.src &#x3D; &#x27;assets/imgs/mapPack_tilesheet.png&#x27;;
+img.onload &#x3D; function() {
+  let tileEngine &#x3D; TileEngine({
+    // tile size
+    tilewidth: 64,
+    tileheight: 64,
+
+    // map size in tiles
+    width: 9,
+    height: 9,
+
+    // tileset object
+    tilesets: [{
+      firstgid: 1,
+      image: img
+    }],
+
+    // layer object
+    layers: [{
+      name: &#x27;ground&#x27;,
+      data: [ 0,  0,  0,  0,  0,  0,  0,  0,  0,
+              0,  0,  6,  7,  7,  8,  0,  0,  0,
+              0,  6,  27, 24, 24, 25, 0,  0,  0,
+              0,  23, 24, 24, 24, 26, 8,  0,  0,
+              0,  23, 24, 24, 24, 24, 26, 8,  0,
+              0,  23, 24, 24, 24, 24, 24, 25, 0,
+              0,  40, 41, 41, 10, 24, 24, 25, 0,
+              0,  0,  0,  0,  40, 41, 41, 42, 0,
+              0,  0,  0,  0,  0,  0,  0,  0,  0 ]
+    }]
+  });
+
+  tileEngine.render();
+}</code></pre>
+  </section>
+  <section role="tabpanel" aria-labelledby=game-canvas-5-es-tab data-tabpanel="es">
+    <pre><code class="lang-js">import { TileEngine } from &#x27;path/to/kontra.mjs&#x27;
+
+let img &#x3D; new Image();
+img.src &#x3D; &#x27;assets/imgs/mapPack_tilesheet.png&#x27;;
+img.onload &#x3D; function() {
+  let tileEngine &#x3D; TileEngine({
+    // tile size
+    tilewidth: 64,
+    tileheight: 64,
+
+    // map size in tiles
+    width: 9,
+    height: 9,
+
+    // tileset object
+    tilesets: [{
+      firstgid: 1,
+      image: img
+    }],
+
+    // layer object
+    layers: [{
+      name: &#x27;ground&#x27;,
+      data: [ 0,  0,  0,  0,  0,  0,  0,  0,  0,
+              0,  0,  6,  7,  7,  8,  0,  0,  0,
+              0,  6,  27, 24, 24, 25, 0,  0,  0,
+              0,  23, 24, 24, 24, 26, 8,  0,  0,
+              0,  23, 24, 24, 24, 24, 26, 8,  0,
+              0,  23, 24, 24, 24, 24, 24, 25, 0,
+              0,  40, 41, 41, 10, 24, 24, 25, 0,
+              0,  0,  0,  0,  40, 41, 41, 42, 0,
+              0,  0,  0,  0,  0,  0,  0,  0,  0 ]
+    }]
+  });
+
+  tileEngine.render();
+}</code></pre>
+  </section>
+  <section role="tabpanel" aria-labelledby=game-canvas-5-bundle-tab data-tabpanel="bundle">
+    <pre><code class="lang-js">import { TileEngine } from &#x27;kontra&#x27;;
+
+let img &#x3D; new Image();
+img.src &#x3D; &#x27;assets/imgs/mapPack_tilesheet.png&#x27;;
+img.onload &#x3D; function() {
+  let tileEngine &#x3D; TileEngine({
+    // tile size
+    tilewidth: 64,
+    tileheight: 64,
+
+    // map size in tiles
+    width: 9,
+    height: 9,
+
+    // tileset object
+    tilesets: [{
+      firstgid: 1,
+      image: img
+    }],
+
+    // layer object
+    layers: [{
+      name: &#x27;ground&#x27;,
+      data: [ 0,  0,  0,  0,  0,  0,  0,  0,  0,
+              0,  0,  6,  7,  7,  8,  0,  0,  0,
+              0,  6,  27, 24, 24, 25, 0,  0,  0,
+              0,  23, 24, 24, 24, 26, 8,  0,  0,
+              0,  23, 24, 24, 24, 24, 26, 8,  0,
+              0,  23, 24, 24, 24, 24, 24, 25, 0,
+              0,  40, 41, 41, 10, 24, 24, 25, 0,
+              0,  0,  0,  0,  40, 41, 41, 42, 0,
+              0,  0,  0,  0,  0,  0,  0,  0,  0 ]
+    }]
+  });
+
+  tileEngine.render();
+}</code></pre>
+  </section>
+</div>
+
+<script>(function() {
+  kontra.init("game-canvas-5");
+  var canvas = document.querySelector("#game-canvas-5");
+  canvas.width = 576;
+  canvas.height = 576;
+  var context = canvas.getContext("2d");
+  // exclude-code:start
+let { TileEngine } = kontra;
+// exclude-code:end
+let img = new Image();
+img.src = 'assets/imgs/mapPack_tilesheet.png';
+img.onload = function() {
+  let tileEngine = TileEngine({
+    // tile size
+    tilewidth: 64,
+    tileheight: 64,
+
+    // map size in tiles
+    width: 9,
+    height: 9,
+
+    // tileset object
+    tilesets: [{
+      firstgid: 1,
+      image: img
+    }],
+
+    // layer object
+    layers: [{
+      name: 'ground',
+      data: [ 0,  0,  0,  0,  0,  0,  0,  0,  0,
+              0,  0,  6,  7,  7,  8,  0,  0,  0,
+              0,  6,  27, 24, 24, 25, 0,  0,  0,
+              0,  23, 24, 24, 24, 26, 8,  0,  0,
+              0,  23, 24, 24, 24, 24, 26, 8,  0,
+              0,  23, 24, 24, 24, 24, 24, 25, 0,
+              0,  40, 41, 41, 10, 24, 24, 25, 0,
+              0,  0,  0,  0,  40, 41, 41, 42, 0,
+              0,  0,  0,  0,  0,  0,  0,  0,  0 ]
+    }]
+  });
+  // exclude-code:start
+  tileEngine.context = context;
+  // exclude-code:end
+
+  tileEngine.render();
+}
+})();</script>        </section>
+        <section>
+          <h2 id="advance-use">
+            <a href="#advance-use" class="section-link">
+              <span>Advance Use</span>
+              <span aria-hidden="true">#</span>
+            </a>
+          </h2>
+
+          <p>Adding all the tileset images and layers to a tile engine can be tedious, especially if you have multiple layers. If you want a simpler way to create a tile engine, Kontra has been written to work directly with the JSON output of the <a href="http://www.mapeditor.org/">Tiled Map Editor</a>.</p>
+<p>The one requirement is that you must preload all of the tileset images and tileset sources using the appropriate <a href="./assets">asset loader functions</a> before you create the tile engine.</p>
+<canvas id="game-canvas-6"></canvas>
+
+<div class="tablist">
+  <ul role="tablist">
+    <li role="presentation" data-tab="global">
+      <button role="tab" id="game-canvas-6-global-tab">Global Object</button>
+    </li>
+    <li role="presentation" data-tab="es">
+      <button role="tab" id="game-canvas-6-es-tab">ES Module Import</button>
+    </li>
+    <li role="presentation" data-tab="bundle">
+      <button role="tab" id="game-canvas-6-bundle-tab">Module Bundler</button>
+    </li>
+    <li role="presentation"></li>
+  </ul>
+  <section role="tabpanel" aria-labelledby=game-canvas-6-global-tab data-tabpanel="global">
+    <pre><code class="lang-js">let { load, TileEngine, dataAssets } &#x3D; kontra
+
+load(&#x27;assets/imgs/mapPack_tilesheet.png&#x27;, &#x27;assets/data/tile_engine_basic.json&#x27;)
+  .then(assets &#x3D;&gt; {
+    let tileEngine &#x3D; TileEngine(dataAssets[&#x27;assets/data/tile_engine_basic&#x27;]);
+    tileEngine.render();
+  });</code></pre>
+  </section>
+  <section role="tabpanel" aria-labelledby=game-canvas-6-es-tab data-tabpanel="es">
+    <pre><code class="lang-js">import { load, TileEngine, dataAssets } from &#x27;path/to/kontra.mjs&#x27;
+
+load(&#x27;assets/imgs/mapPack_tilesheet.png&#x27;, &#x27;assets/data/tile_engine_basic.json&#x27;)
+  .then(assets &#x3D;&gt; {
+    let tileEngine &#x3D; TileEngine(dataAssets[&#x27;assets/data/tile_engine_basic&#x27;]);
+    tileEngine.render();
+  });</code></pre>
+  </section>
+  <section role="tabpanel" aria-labelledby=game-canvas-6-bundle-tab data-tabpanel="bundle">
+    <pre><code class="lang-js">import { load, TileEngine, dataAssets } from &#x27;kontra&#x27;;
+
+load(&#x27;assets/imgs/mapPack_tilesheet.png&#x27;, &#x27;assets/data/tile_engine_basic.json&#x27;)
+  .then(assets &#x3D;&gt; {
+    let tileEngine &#x3D; TileEngine(dataAssets[&#x27;assets/data/tile_engine_basic&#x27;]);
+    tileEngine.render();
+  });</code></pre>
+  </section>
+</div>
+
+<script>(function() {
+  kontra.init("game-canvas-6");
+  var canvas = document.querySelector("#game-canvas-6");
+  canvas.width = 576;
+  canvas.height = 576;
+  var context = canvas.getContext("2d");
+  // exclude-code:start
+let { TileEngine, load, dataAssets } = kontra;
+// exclude-code:end
+load('assets/imgs/mapPack_tilesheet.png', 'assets/data/tile_engine_basic.json')
+  .then(assets => {
+    let tileEngine = TileEngine(dataAssets['assets/data/tile_engine_basic']);
+    // exclude-code:start
+    tileEngine.context = context;
+    // exclude-code:end
+    tileEngine.render();
+  });
+})();</script>        </section>
+        <section>
+          <h2 id="moving-the camera">
+            <a href="#moving-the camera" class="section-link">
+              <span>Moving the Camera</span>
+              <span aria-hidden="true">#</span>
+            </a>
+          </h2>
+
+          <p>If your tilemap is larger than the canvas size, you can move the tilemap camera to change how the tilemap is drawn. Use the tile engines <a href="#sx">sx</a> and <a href="#sy">sy</a> properties to move the camera. Just like drawing an image, the cameras coordinates are the top left corner.</p>
+<p>The <code>sx</code> and <code>sy</code> coordinates will never draw the tile map below 0 or beyond the last row or column of the tile map.</p>
+<canvas id="game-canvas-7"></canvas>
+
+<div class="tablist">
+  <ul role="tablist">
+    <li role="presentation" data-tab="global">
+      <button role="tab" id="game-canvas-7-global-tab">Global Object</button>
+    </li>
+    <li role="presentation" data-tab="es">
+      <button role="tab" id="game-canvas-7-es-tab">ES Module Import</button>
+    </li>
+    <li role="presentation" data-tab="bundle">
+      <button role="tab" id="game-canvas-7-bundle-tab">Module Bundler</button>
+    </li>
+    <li role="presentation"></li>
+  </ul>
+  <section role="tabpanel" aria-labelledby=game-canvas-7-global-tab data-tabpanel="global">
+    <pre><code class="lang-js">let { load, TileEngine, dataAssets, GameLoop } &#x3D; kontra
+
+load(&#x27;assets/imgs/mapPack_tilesheet.png&#x27;, &#x27;assets/data/tile_engine_camera.json&#x27;)
+  .then(function() {
+    let tileEngine &#x3D; TileEngine(dataAssets[&#x27;assets/data/tile_engine_camera&#x27;]);
+
+    let sx &#x3D; 1;
+    let loop &#x3D; GameLoop({
+      update: function() {
+        tileEngine.sx +&#x3D; sx;
+
+        if (tileEngine.sx &lt;&#x3D; 0 || tileEngine.sx &gt;&#x3D; 320) {
+          sx &#x3D; -sx;
+        }
+      },
+      render: function() {
+        tileEngine.render();
+      }
+    });
+
+    loop.start();
+  });</code></pre>
+  </section>
+  <section role="tabpanel" aria-labelledby=game-canvas-7-es-tab data-tabpanel="es">
+    <pre><code class="lang-js">import { load, TileEngine, dataAssets, GameLoop } from &#x27;path/to/kontra.mjs&#x27;
+
+load(&#x27;assets/imgs/mapPack_tilesheet.png&#x27;, &#x27;assets/data/tile_engine_camera.json&#x27;)
+  .then(function() {
+    let tileEngine &#x3D; TileEngine(dataAssets[&#x27;assets/data/tile_engine_camera&#x27;]);
+
+    let sx &#x3D; 1;
+    let loop &#x3D; GameLoop({
+      update: function() {
+        tileEngine.sx +&#x3D; sx;
+
+        if (tileEngine.sx &lt;&#x3D; 0 || tileEngine.sx &gt;&#x3D; 320) {
+          sx &#x3D; -sx;
+        }
+      },
+      render: function() {
+        tileEngine.render();
+      }
+    });
+
+    loop.start();
+  });</code></pre>
+  </section>
+  <section role="tabpanel" aria-labelledby=game-canvas-7-bundle-tab data-tabpanel="bundle">
+    <pre><code class="lang-js">import { load, TileEngine, dataAssets, GameLoop } from &#x27;kontra&#x27;;
+
+load(&#x27;assets/imgs/mapPack_tilesheet.png&#x27;, &#x27;assets/data/tile_engine_camera.json&#x27;)
+  .then(function() {
+    let tileEngine &#x3D; TileEngine(dataAssets[&#x27;assets/data/tile_engine_camera&#x27;]);
+
+    let sx &#x3D; 1;
+    let loop &#x3D; GameLoop({
+      update: function() {
+        tileEngine.sx +&#x3D; sx;
+
+        if (tileEngine.sx &lt;&#x3D; 0 || tileEngine.sx &gt;&#x3D; 320) {
+          sx &#x3D; -sx;
+        }
+      },
+      render: function() {
+        tileEngine.render();
+      }
+    });
+
+    loop.start();
+  });</code></pre>
+  </section>
+</div>
+
+<script>(function() {
+  kontra.init("game-canvas-7");
+  var canvas = document.querySelector("#game-canvas-7");
+  canvas.width = 576;
+  canvas.height = 576;
+  var context = canvas.getContext("2d");
+  // exclude-code:start
+let { TileEngine, load, dataAssets, GameLoop } = kontra;
+// exclude-code:end
+load('assets/imgs/mapPack_tilesheet.png', 'assets/data/tile_engine_camera.json')
+  .then(function() {
+    let tileEngine = TileEngine(dataAssets['assets/data/tile_engine_camera']);
+    // exclude-code:start
+    tileEngine.context = context;
+    // exclude-code:end
+
+    let sx = 1;
+    let loop = GameLoop({
+      update: function() {
+        tileEngine.sx += sx;
+
+        if (tileEngine.sx <= 0 || tileEngine.sx >= 320) {
+          sx = -sx;
+        }
+      },
+      render: function() {
+        tileEngine.render();
+      }
+    });
+
+    loop.start();
+  });
+})();</script>        </section>
 
         <section>
           <h2 id="context">

--- a/docs/api/tileEngine.html
+++ b/docs/api/tileEngine.html
@@ -198,13 +198,6 @@
           <h2 id="toc"><a href="#toc" class="section-link">Table of Contents<span aria-hidden="true">#</span></a></h2>
 
           <ul aria-labelledby="toc">
-            <li>
-              <ul>
-                <li><a href="api/tileEngine#basic-use">Basic Use</a></li>
-                <li><a href="api/tileEngine#advance-use">Advance Use</a></li>
-                <li><a href="api/tileEngine#moving-the camera">Moving the Camera</a></li>
-              </ul>
-            </li>
 
             <li>
               <h3 id="properties">Properties</h3>
@@ -300,410 +293,6 @@
           </ul>
         </section>
 
-        <section>
-          <h2 id="basic-use">
-            <a href="#basic-use" class="section-link">
-              <span>Basic Use</span>
-              <span aria-hidden="true">#</span>
-            </a>
-          </h2>
-
-          <p>Creating a tile map requires three things:</p>
-<ol>
-<li>Dimensions of the tile map and a tile</li>
-<li>At least one tileset with an image</li>
-<li>At least one layer with data</li>
-</ol>
-<p>To set up the tile engine, you&#39;ll need to pass it the width and height of a tile (in pixels) and the width and height of the map (in number of tiles).</p>
-<p>You&#39;ll then need to add at least one tileset with an image as well as firstgid, or first tile index of the tileset. The first tileset will always have a firstgid of 1 as 0 represents an empty tile.</p>
-<p>Lastly, you&#39;ll need to add at least one named layer with data. A layer tells the tile engine which tiles from the tileset image to use at what position on the map.</p>
-<p>Once all tileset images and all layers have been added, you can render the tile engine by calling its <a href="#render">render()</a> function.</p>
-<canvas id="game-canvas-5"></canvas>
-
-<div class="tablist">
-  <ul role="tablist">
-    <li role="presentation" data-tab="global">
-      <button role="tab" id="game-canvas-5-global-tab">Global Object</button>
-    </li>
-    <li role="presentation" data-tab="es">
-      <button role="tab" id="game-canvas-5-es-tab">ES Module Import</button>
-    </li>
-    <li role="presentation" data-tab="bundle">
-      <button role="tab" id="game-canvas-5-bundle-tab">Module Bundler</button>
-    </li>
-    <li role="presentation"></li>
-  </ul>
-  <section role="tabpanel" aria-labelledby=game-canvas-5-global-tab data-tabpanel="global">
-    <pre><code class="lang-js">let { TileEngine } &#x3D; kontra
-
-let img &#x3D; new Image();
-img.src &#x3D; &#x27;assets/imgs/mapPack_tilesheet.png&#x27;;
-img.onload &#x3D; function() {
-  let tileEngine &#x3D; TileEngine({
-    // tile size
-    tilewidth: 64,
-    tileheight: 64,
-
-    // map size in tiles
-    width: 9,
-    height: 9,
-
-    // tileset object
-    tilesets: [{
-      firstgid: 1,
-      image: img
-    }],
-
-    // layer object
-    layers: [{
-      name: &#x27;ground&#x27;,
-      data: [ 0,  0,  0,  0,  0,  0,  0,  0,  0,
-              0,  0,  6,  7,  7,  8,  0,  0,  0,
-              0,  6,  27, 24, 24, 25, 0,  0,  0,
-              0,  23, 24, 24, 24, 26, 8,  0,  0,
-              0,  23, 24, 24, 24, 24, 26, 8,  0,
-              0,  23, 24, 24, 24, 24, 24, 25, 0,
-              0,  40, 41, 41, 10, 24, 24, 25, 0,
-              0,  0,  0,  0,  40, 41, 41, 42, 0,
-              0,  0,  0,  0,  0,  0,  0,  0,  0 ]
-    }]
-  });
-
-  tileEngine.render();
-}</code></pre>
-  </section>
-  <section role="tabpanel" aria-labelledby=game-canvas-5-es-tab data-tabpanel="es">
-    <pre><code class="lang-js">import { TileEngine } from &#x27;path/to/kontra.mjs&#x27;
-
-let img &#x3D; new Image();
-img.src &#x3D; &#x27;assets/imgs/mapPack_tilesheet.png&#x27;;
-img.onload &#x3D; function() {
-  let tileEngine &#x3D; TileEngine({
-    // tile size
-    tilewidth: 64,
-    tileheight: 64,
-
-    // map size in tiles
-    width: 9,
-    height: 9,
-
-    // tileset object
-    tilesets: [{
-      firstgid: 1,
-      image: img
-    }],
-
-    // layer object
-    layers: [{
-      name: &#x27;ground&#x27;,
-      data: [ 0,  0,  0,  0,  0,  0,  0,  0,  0,
-              0,  0,  6,  7,  7,  8,  0,  0,  0,
-              0,  6,  27, 24, 24, 25, 0,  0,  0,
-              0,  23, 24, 24, 24, 26, 8,  0,  0,
-              0,  23, 24, 24, 24, 24, 26, 8,  0,
-              0,  23, 24, 24, 24, 24, 24, 25, 0,
-              0,  40, 41, 41, 10, 24, 24, 25, 0,
-              0,  0,  0,  0,  40, 41, 41, 42, 0,
-              0,  0,  0,  0,  0,  0,  0,  0,  0 ]
-    }]
-  });
-
-  tileEngine.render();
-}</code></pre>
-  </section>
-  <section role="tabpanel" aria-labelledby=game-canvas-5-bundle-tab data-tabpanel="bundle">
-    <pre><code class="lang-js">import { TileEngine } from &#x27;kontra&#x27;;
-
-let img &#x3D; new Image();
-img.src &#x3D; &#x27;assets/imgs/mapPack_tilesheet.png&#x27;;
-img.onload &#x3D; function() {
-  let tileEngine &#x3D; TileEngine({
-    // tile size
-    tilewidth: 64,
-    tileheight: 64,
-
-    // map size in tiles
-    width: 9,
-    height: 9,
-
-    // tileset object
-    tilesets: [{
-      firstgid: 1,
-      image: img
-    }],
-
-    // layer object
-    layers: [{
-      name: &#x27;ground&#x27;,
-      data: [ 0,  0,  0,  0,  0,  0,  0,  0,  0,
-              0,  0,  6,  7,  7,  8,  0,  0,  0,
-              0,  6,  27, 24, 24, 25, 0,  0,  0,
-              0,  23, 24, 24, 24, 26, 8,  0,  0,
-              0,  23, 24, 24, 24, 24, 26, 8,  0,
-              0,  23, 24, 24, 24, 24, 24, 25, 0,
-              0,  40, 41, 41, 10, 24, 24, 25, 0,
-              0,  0,  0,  0,  40, 41, 41, 42, 0,
-              0,  0,  0,  0,  0,  0,  0,  0,  0 ]
-    }]
-  });
-
-  tileEngine.render();
-}</code></pre>
-  </section>
-</div>
-
-<script>(function() {
-  kontra.init("game-canvas-5");
-  var canvas = document.querySelector("#game-canvas-5");
-  canvas.width = 576;
-  canvas.height = 576;
-  var context = canvas.getContext("2d");
-  // exclude-code:start
-let { TileEngine } = kontra;
-// exclude-code:end
-let img = new Image();
-img.src = 'assets/imgs/mapPack_tilesheet.png';
-img.onload = function() {
-  let tileEngine = TileEngine({
-    // tile size
-    tilewidth: 64,
-    tileheight: 64,
-
-    // map size in tiles
-    width: 9,
-    height: 9,
-
-    // tileset object
-    tilesets: [{
-      firstgid: 1,
-      image: img
-    }],
-
-    // layer object
-    layers: [{
-      name: 'ground',
-      data: [ 0,  0,  0,  0,  0,  0,  0,  0,  0,
-              0,  0,  6,  7,  7,  8,  0,  0,  0,
-              0,  6,  27, 24, 24, 25, 0,  0,  0,
-              0,  23, 24, 24, 24, 26, 8,  0,  0,
-              0,  23, 24, 24, 24, 24, 26, 8,  0,
-              0,  23, 24, 24, 24, 24, 24, 25, 0,
-              0,  40, 41, 41, 10, 24, 24, 25, 0,
-              0,  0,  0,  0,  40, 41, 41, 42, 0,
-              0,  0,  0,  0,  0,  0,  0,  0,  0 ]
-    }]
-  });
-  // exclude-code:start
-  tileEngine.context = context;
-  // exclude-code:end
-
-  tileEngine.render();
-}
-})();</script>        </section>
-        <section>
-          <h2 id="advance-use">
-            <a href="#advance-use" class="section-link">
-              <span>Advance Use</span>
-              <span aria-hidden="true">#</span>
-            </a>
-          </h2>
-
-          <p>Adding all the tileset images and layers to a tile engine can be tedious, especially if you have multiple layers. If you want a simpler way to create a tile engine, Kontra has been written to work directly with the JSON output of the <a href="http://www.mapeditor.org/">Tiled Map Editor</a>.</p>
-<p>The one requirement is that you must preload all of the tileset images and tileset sources using the appropriate <a href="./assets">asset loader functions</a> before you create the tile engine.</p>
-<canvas id="game-canvas-6"></canvas>
-
-<div class="tablist">
-  <ul role="tablist">
-    <li role="presentation" data-tab="global">
-      <button role="tab" id="game-canvas-6-global-tab">Global Object</button>
-    </li>
-    <li role="presentation" data-tab="es">
-      <button role="tab" id="game-canvas-6-es-tab">ES Module Import</button>
-    </li>
-    <li role="presentation" data-tab="bundle">
-      <button role="tab" id="game-canvas-6-bundle-tab">Module Bundler</button>
-    </li>
-    <li role="presentation"></li>
-  </ul>
-  <section role="tabpanel" aria-labelledby=game-canvas-6-global-tab data-tabpanel="global">
-    <pre><code class="lang-js">let { load, TileEngine, dataAssets } &#x3D; kontra
-
-load(&#x27;assets/imgs/mapPack_tilesheet.png&#x27;, &#x27;assets/data/tile_engine_basic.json&#x27;)
-  .then(assets &#x3D;&gt; {
-    let tileEngine &#x3D; TileEngine(dataAssets[&#x27;assets/data/tile_engine_basic&#x27;]);
-    tileEngine.render();
-  });</code></pre>
-  </section>
-  <section role="tabpanel" aria-labelledby=game-canvas-6-es-tab data-tabpanel="es">
-    <pre><code class="lang-js">import { load, TileEngine, dataAssets } from &#x27;path/to/kontra.mjs&#x27;
-
-load(&#x27;assets/imgs/mapPack_tilesheet.png&#x27;, &#x27;assets/data/tile_engine_basic.json&#x27;)
-  .then(assets &#x3D;&gt; {
-    let tileEngine &#x3D; TileEngine(dataAssets[&#x27;assets/data/tile_engine_basic&#x27;]);
-    tileEngine.render();
-  });</code></pre>
-  </section>
-  <section role="tabpanel" aria-labelledby=game-canvas-6-bundle-tab data-tabpanel="bundle">
-    <pre><code class="lang-js">import { load, TileEngine, dataAssets } from &#x27;kontra&#x27;;
-
-load(&#x27;assets/imgs/mapPack_tilesheet.png&#x27;, &#x27;assets/data/tile_engine_basic.json&#x27;)
-  .then(assets &#x3D;&gt; {
-    let tileEngine &#x3D; TileEngine(dataAssets[&#x27;assets/data/tile_engine_basic&#x27;]);
-    tileEngine.render();
-  });</code></pre>
-  </section>
-</div>
-
-<script>(function() {
-  kontra.init("game-canvas-6");
-  var canvas = document.querySelector("#game-canvas-6");
-  canvas.width = 576;
-  canvas.height = 576;
-  var context = canvas.getContext("2d");
-  // exclude-code:start
-let { TileEngine, load, dataAssets } = kontra;
-// exclude-code:end
-load('assets/imgs/mapPack_tilesheet.png', 'assets/data/tile_engine_basic.json')
-  .then(assets => {
-    let tileEngine = TileEngine(dataAssets['assets/data/tile_engine_basic']);
-    // exclude-code:start
-    tileEngine.context = context;
-    // exclude-code:end
-    tileEngine.render();
-  });
-})();</script>        </section>
-        <section>
-          <h2 id="moving-the camera">
-            <a href="#moving-the camera" class="section-link">
-              <span>Moving the Camera</span>
-              <span aria-hidden="true">#</span>
-            </a>
-          </h2>
-
-          <p>If your tilemap is larger than the canvas size, you can move the tilemap camera to change how the tilemap is drawn. Use the tile engines <a href="#sx">sx</a> and <a href="#sy">sy</a> properties to move the camera. Just like drawing an image, the cameras coordinates are the top left corner.</p>
-<p>The <code>sx</code> and <code>sy</code> coordinates will never draw the tile map below 0 or beyond the last row or column of the tile map.</p>
-<canvas id="game-canvas-7"></canvas>
-
-<div class="tablist">
-  <ul role="tablist">
-    <li role="presentation" data-tab="global">
-      <button role="tab" id="game-canvas-7-global-tab">Global Object</button>
-    </li>
-    <li role="presentation" data-tab="es">
-      <button role="tab" id="game-canvas-7-es-tab">ES Module Import</button>
-    </li>
-    <li role="presentation" data-tab="bundle">
-      <button role="tab" id="game-canvas-7-bundle-tab">Module Bundler</button>
-    </li>
-    <li role="presentation"></li>
-  </ul>
-  <section role="tabpanel" aria-labelledby=game-canvas-7-global-tab data-tabpanel="global">
-    <pre><code class="lang-js">let { load, TileEngine, dataAssets, GameLoop } &#x3D; kontra
-
-load(&#x27;assets/imgs/mapPack_tilesheet.png&#x27;, &#x27;assets/data/tile_engine_camera.json&#x27;)
-  .then(function() {
-    let tileEngine &#x3D; TileEngine(dataAssets[&#x27;assets/data/tile_engine_camera&#x27;]);
-
-    let sx &#x3D; 1;
-    let loop &#x3D; GameLoop({
-      update: function() {
-        tileEngine.sx +&#x3D; sx;
-
-        if (tileEngine.sx &lt;&#x3D; 0 || tileEngine.sx &gt;&#x3D; 320) {
-          sx &#x3D; -sx;
-        }
-      },
-      render: function() {
-        tileEngine.render();
-      }
-    });
-
-    loop.start();
-  });</code></pre>
-  </section>
-  <section role="tabpanel" aria-labelledby=game-canvas-7-es-tab data-tabpanel="es">
-    <pre><code class="lang-js">import { load, TileEngine, dataAssets, GameLoop } from &#x27;path/to/kontra.mjs&#x27;
-
-load(&#x27;assets/imgs/mapPack_tilesheet.png&#x27;, &#x27;assets/data/tile_engine_camera.json&#x27;)
-  .then(function() {
-    let tileEngine &#x3D; TileEngine(dataAssets[&#x27;assets/data/tile_engine_camera&#x27;]);
-
-    let sx &#x3D; 1;
-    let loop &#x3D; GameLoop({
-      update: function() {
-        tileEngine.sx +&#x3D; sx;
-
-        if (tileEngine.sx &lt;&#x3D; 0 || tileEngine.sx &gt;&#x3D; 320) {
-          sx &#x3D; -sx;
-        }
-      },
-      render: function() {
-        tileEngine.render();
-      }
-    });
-
-    loop.start();
-  });</code></pre>
-  </section>
-  <section role="tabpanel" aria-labelledby=game-canvas-7-bundle-tab data-tabpanel="bundle">
-    <pre><code class="lang-js">import { load, TileEngine, dataAssets, GameLoop } from &#x27;kontra&#x27;;
-
-load(&#x27;assets/imgs/mapPack_tilesheet.png&#x27;, &#x27;assets/data/tile_engine_camera.json&#x27;)
-  .then(function() {
-    let tileEngine &#x3D; TileEngine(dataAssets[&#x27;assets/data/tile_engine_camera&#x27;]);
-
-    let sx &#x3D; 1;
-    let loop &#x3D; GameLoop({
-      update: function() {
-        tileEngine.sx +&#x3D; sx;
-
-        if (tileEngine.sx &lt;&#x3D; 0 || tileEngine.sx &gt;&#x3D; 320) {
-          sx &#x3D; -sx;
-        }
-      },
-      render: function() {
-        tileEngine.render();
-      }
-    });
-
-    loop.start();
-  });</code></pre>
-  </section>
-</div>
-
-<script>(function() {
-  kontra.init("game-canvas-7");
-  var canvas = document.querySelector("#game-canvas-7");
-  canvas.width = 576;
-  canvas.height = 576;
-  var context = canvas.getContext("2d");
-  // exclude-code:start
-let { TileEngine, load, dataAssets, GameLoop } = kontra;
-// exclude-code:end
-load('assets/imgs/mapPack_tilesheet.png', 'assets/data/tile_engine_camera.json')
-  .then(function() {
-    let tileEngine = TileEngine(dataAssets['assets/data/tile_engine_camera']);
-    // exclude-code:start
-    tileEngine.context = context;
-    // exclude-code:end
-
-    let sx = 1;
-    let loop = GameLoop({
-      update: function() {
-        tileEngine.sx += sx;
-
-        if (tileEngine.sx <= 0 || tileEngine.sx >= 320) {
-          sx = -sx;
-        }
-      },
-      render: function() {
-        tileEngine.render();
-      }
-    });
-
-    loop.start();
-  });
-})();</script>        </section>
 
         <section>
           <h2 id="context">
@@ -749,7 +338,7 @@ load('assets/imgs/mapPack_tilesheet.png', 'assets/data/tile_engine_camera.json')
     </li>
     <li role="presentation"></li>
   </ul>
-  <section role="tabpanel" aria-labelledby=layercollideswith-global-tab data-tabpanel="global"><pre><code class="lang-js">let { TileEngine, Sprite } = kontra;
+  <section role="tabpanel" aria-labelledby=layercollideswith-global-tab data-tabpanel="global"><pre><code class="language-js">let { TileEngine, Sprite } = kontra;
 
 let tileEngine = TileEngine({
   tilewidth: 32,
@@ -779,9 +368,8 @@ tileEngine.layerCollidesWith(&#39;collision&#39;, sprite);  //=&gt; false
 
 sprite.y = 28;
 
-tileEngine.layerCollidesWith(&#39;collision&#39;, sprite);  //=&gt; true
-</code></pre></section>
-  <section role="tabpanel" aria-labelledby=layercollideswith-es-tab data-tabpanel="es"><pre><code class="lang-js">import { TileEngine, Sprite } from 'path/to/kontra.mjs';
+tileEngine.layerCollidesWith(&#39;collision&#39;, sprite);  //=&gt; true</code></pre></section>
+  <section role="tabpanel" aria-labelledby=layercollideswith-es-tab data-tabpanel="es"><pre><code class="language-js">import { TileEngine, Sprite } from 'path/to/kontra.mjs';
 
 let tileEngine = TileEngine({
   tilewidth: 32,
@@ -811,9 +399,8 @@ tileEngine.layerCollidesWith(&#39;collision&#39;, sprite);  //=&gt; false
 
 sprite.y = 28;
 
-tileEngine.layerCollidesWith(&#39;collision&#39;, sprite);  //=&gt; true
-</code></pre></section>
-  <section role="tabpanel" aria-labelledby=layercollideswith-bundle-tab data-tabpanel="bundle"><pre><code class="lang-js">import { TileEngine, Sprite } from &#39;kontra&#39;;
+tileEngine.layerCollidesWith(&#39;collision&#39;, sprite);  //=&gt; true</code></pre></section>
+  <section role="tabpanel" aria-labelledby=layercollideswith-bundle-tab data-tabpanel="bundle"><pre><code class="language-js">import { TileEngine, Sprite } from &#39;kontra&#39;;
 
 let tileEngine = TileEngine({
   tilewidth: 32,
@@ -843,8 +430,7 @@ tileEngine.layerCollidesWith(&#39;collision&#39;, sprite);  //=&gt; false
 
 sprite.y = 28;
 
-tileEngine.layerCollidesWith(&#39;collision&#39;, sprite);  //=&gt; true
-</code></pre></section>
+tileEngine.layerCollidesWith(&#39;collision&#39;, sprite);  //=&gt; true</code></pre></section>
 </div>
           <h3 id="title-layerCollidesWith"><span class="visually-hidden">layerCollidesWith</span> Parameters</span></h3>
           <dl aria-labelledby="title-layerCollidesWith">
@@ -952,7 +538,7 @@ tileEngine.layerCollidesWith(&#39;collision&#39;, sprite);  //=&gt; true
     </li>
     <li role="presentation"></li>
   </ul>
-  <section role="tabpanel" aria-labelledby=settileatlayer-global-tab data-tabpanel="global"><pre><code class="lang-js">let { TileEngine } = kontra;
+  <section role="tabpanel" aria-labelledby=settileatlayer-global-tab data-tabpanel="global"><pre><code class="language-js">let { TileEngine } = kontra;
 
 let tileEngine = TileEngine({
   tilewidth: 32,
@@ -972,9 +558,8 @@ let tileEngine = TileEngine({
 });
 
 tileEngine.setTileAtLayer(&#39;collision&#39;, {row: 2, col: 1}, 10);
-tileEngine.tileAtLayer(&#39;collision&#39;, {row: 2, col: 1});  //=&gt; 10
-</code></pre></section>
-  <section role="tabpanel" aria-labelledby=settileatlayer-es-tab data-tabpanel="es"><pre><code class="lang-js">import { TileEngine } from 'path/to/kontra.mjs';
+tileEngine.tileAtLayer(&#39;collision&#39;, {row: 2, col: 1});  //=&gt; 10</code></pre></section>
+  <section role="tabpanel" aria-labelledby=settileatlayer-es-tab data-tabpanel="es"><pre><code class="language-js">import { TileEngine } from 'path/to/kontra.mjs';
 
 let tileEngine = TileEngine({
   tilewidth: 32,
@@ -994,9 +579,8 @@ let tileEngine = TileEngine({
 });
 
 tileEngine.setTileAtLayer(&#39;collision&#39;, {row: 2, col: 1}, 10);
-tileEngine.tileAtLayer(&#39;collision&#39;, {row: 2, col: 1});  //=&gt; 10
-</code></pre></section>
-  <section role="tabpanel" aria-labelledby=settileatlayer-bundle-tab data-tabpanel="bundle"><pre><code class="lang-js">import { TileEngine } from &#39;kontra&#39;;
+tileEngine.tileAtLayer(&#39;collision&#39;, {row: 2, col: 1});  //=&gt; 10</code></pre></section>
+  <section role="tabpanel" aria-labelledby=settileatlayer-bundle-tab data-tabpanel="bundle"><pre><code class="language-js">import { TileEngine } from &#39;kontra&#39;;
 
 let tileEngine = TileEngine({
   tilewidth: 32,
@@ -1016,8 +600,7 @@ let tileEngine = TileEngine({
 });
 
 tileEngine.setTileAtLayer(&#39;collision&#39;, {row: 2, col: 1}, 10);
-tileEngine.tileAtLayer(&#39;collision&#39;, {row: 2, col: 1});  //=&gt; 10
-</code></pre></section>
+tileEngine.tileAtLayer(&#39;collision&#39;, {row: 2, col: 1});  //=&gt; 10</code></pre></section>
 </div>
           <h3 id="title-setTileAtLayer"><span class="visually-hidden">setTileAtLayer</span> Parameters</span></h3>
           <dl aria-labelledby="title-setTileAtLayer">
@@ -1086,7 +669,7 @@ tileEngine.tileAtLayer(&#39;collision&#39;, {row: 2, col: 1});  //=&gt; 10
     </li>
     <li role="presentation"></li>
   </ul>
-  <section role="tabpanel" aria-labelledby=tileatlayer-global-tab data-tabpanel="global"><pre><code class="lang-js">let { TileEngine } = kontra;
+  <section role="tabpanel" aria-labelledby=tileatlayer-global-tab data-tabpanel="global"><pre><code class="language-js">let { TileEngine } = kontra;
 
 let tileEngine = TileEngine({
   tilewidth: 32,
@@ -1106,9 +689,8 @@ let tileEngine = TileEngine({
 });
 
 tileEngine.tileAtLayer(&#39;collision&#39;, {x: 50, y: 50});  //=&gt; 1
-tileEngine.tileAtLayer(&#39;collision&#39;, {row: 2, col: 1});  //=&gt; 2
-</code></pre></section>
-  <section role="tabpanel" aria-labelledby=tileatlayer-es-tab data-tabpanel="es"><pre><code class="lang-js">import { TileEngine } from 'path/to/kontra.mjs';
+tileEngine.tileAtLayer(&#39;collision&#39;, {row: 2, col: 1});  //=&gt; 2</code></pre></section>
+  <section role="tabpanel" aria-labelledby=tileatlayer-es-tab data-tabpanel="es"><pre><code class="language-js">import { TileEngine } from 'path/to/kontra.mjs';
 
 let tileEngine = TileEngine({
   tilewidth: 32,
@@ -1128,9 +710,8 @@ let tileEngine = TileEngine({
 });
 
 tileEngine.tileAtLayer(&#39;collision&#39;, {x: 50, y: 50});  //=&gt; 1
-tileEngine.tileAtLayer(&#39;collision&#39;, {row: 2, col: 1});  //=&gt; 2
-</code></pre></section>
-  <section role="tabpanel" aria-labelledby=tileatlayer-bundle-tab data-tabpanel="bundle"><pre><code class="lang-js">import { TileEngine } from &#39;kontra&#39;;
+tileEngine.tileAtLayer(&#39;collision&#39;, {row: 2, col: 1});  //=&gt; 2</code></pre></section>
+  <section role="tabpanel" aria-labelledby=tileatlayer-bundle-tab data-tabpanel="bundle"><pre><code class="language-js">import { TileEngine } from &#39;kontra&#39;;
 
 let tileEngine = TileEngine({
   tilewidth: 32,
@@ -1150,8 +731,7 @@ let tileEngine = TileEngine({
 });
 
 tileEngine.tileAtLayer(&#39;collision&#39;, {x: 50, y: 50});  //=&gt; 1
-tileEngine.tileAtLayer(&#39;collision&#39;, {row: 2, col: 1});  //=&gt; 2
-</code></pre></section>
+tileEngine.tileAtLayer(&#39;collision&#39;, {row: 2, col: 1});  //=&gt; 2</code></pre></section>
 </div>
           <h3 id="title-tileAtLayer"><span class="visually-hidden">tileAtLayer</span> Parameters</span></h3>
           <dl aria-labelledby="title-tileAtLayer">

--- a/docs/api/vector.html
+++ b/docs/api/vector.html
@@ -82,18 +82,15 @@
     </li>
     <li role="presentation"></li>
   </ul>
-  <section role="tabpanel" aria-labelledby=vector-global-tab data-tabpanel="global"><pre><code class="lang-js">let { Vector } = kontra;
+  <section role="tabpanel" aria-labelledby=vector-global-tab data-tabpanel="global"><pre><code class="language-js">let { Vector } = kontra;
 
-let vector = Vector(100, 200);
-</code></pre></section>
-  <section role="tabpanel" aria-labelledby=vector-es-tab data-tabpanel="es"><pre><code class="lang-js">import { Vector } from 'path/to/kontra.mjs';
+let vector = Vector(100, 200);</code></pre></section>
+  <section role="tabpanel" aria-labelledby=vector-es-tab data-tabpanel="es"><pre><code class="language-js">import { Vector } from 'path/to/kontra.mjs';
 
-let vector = Vector(100, 200);
-</code></pre></section>
-  <section role="tabpanel" aria-labelledby=vector-bundle-tab data-tabpanel="bundle"><pre><code class="lang-js">import { Vector } from &#39;kontra&#39;;
+let vector = Vector(100, 200);</code></pre></section>
+  <section role="tabpanel" aria-labelledby=vector-bundle-tab data-tabpanel="bundle"><pre><code class="language-js">import { Vector } from &#39;kontra&#39;;
 
-let vector = Vector(100, 200);
-</code></pre></section>
+let vector = Vector(100, 200);</code></pre></section>
 </div>
         <h3 id="title-Vector"><span class="visually-hidden">Vector</span> Parameters</span></h3>
         <dl aria-labelledby="title-Vector">
@@ -203,7 +200,7 @@ let vector = Vector(100, 200);
     </li>
     <li role="presentation"></li>
   </ul>
-  <section role="tabpanel" aria-labelledby=clamp-global-tab data-tabpanel="global"><pre><code class="lang-js">let { Vector } = kontra;
+  <section role="tabpanel" aria-labelledby=clamp-global-tab data-tabpanel="global"><pre><code class="language-js">let { Vector } = kontra;
 
 let vector = Vector(100, 200);
 vector.clamp(0, 0, 200, 300);
@@ -215,9 +212,8 @@ vector.y -= 300;
 console.log(vector.y);  //=&gt; 0
 
 vector.add({x: -500, y: 500});
-console.log(vector);    //=&gt; {x: 0, y: 300}
-</code></pre></section>
-  <section role="tabpanel" aria-labelledby=clamp-es-tab data-tabpanel="es"><pre><code class="lang-js">import { Vector } from 'path/to/kontra.mjs';
+console.log(vector);    //=&gt; {x: 0, y: 300}</code></pre></section>
+  <section role="tabpanel" aria-labelledby=clamp-es-tab data-tabpanel="es"><pre><code class="language-js">import { Vector } from 'path/to/kontra.mjs';
 
 let vector = Vector(100, 200);
 vector.clamp(0, 0, 200, 300);
@@ -229,9 +225,8 @@ vector.y -= 300;
 console.log(vector.y);  //=&gt; 0
 
 vector.add({x: -500, y: 500});
-console.log(vector);    //=&gt; {x: 0, y: 300}
-</code></pre></section>
-  <section role="tabpanel" aria-labelledby=clamp-bundle-tab data-tabpanel="bundle"><pre><code class="lang-js">import { Vector } from &#39;kontra&#39;;
+console.log(vector);    //=&gt; {x: 0, y: 300}</code></pre></section>
+  <section role="tabpanel" aria-labelledby=clamp-bundle-tab data-tabpanel="bundle"><pre><code class="language-js">import { Vector } from &#39;kontra&#39;;
 
 let vector = Vector(100, 200);
 vector.clamp(0, 0, 200, 300);
@@ -243,8 +238,7 @@ vector.y -= 300;
 console.log(vector.y);  //=&gt; 0
 
 vector.add({x: -500, y: 500});
-console.log(vector);    //=&gt; {x: 0, y: 300}
-</code></pre></section>
+console.log(vector);    //=&gt; {x: 0, y: 300}</code></pre></section>
 </div>
           <h3 id="title-clamp"><span class="visually-hidden">clamp</span> Parameters</span></h3>
           <dl aria-labelledby="title-clamp">

--- a/docs/download.html
+++ b/docs/download.html
@@ -74,7 +74,7 @@
 <li><a href="https://raw.githubusercontent.com/straker/kontra/master/kontra.js">Global object development version</a></li>
 <li><a href="https://raw.githubusercontent.com/straker/kontra/master/kontra.min.mjs">ES Module production version</a></li>
 <li><a href="https://raw.githubusercontent.com/straker/kontra/master/kontra.mjs">ES Module development version</a></li>
-<li>[TGZ file](<a href="https://registry.npmjs.org/kontra/-/kontra-%7B%7B">https://registry.npmjs.org/kontra/-/kontra-{{</a> packageVersion }}.tgz)</li>
+<li><a href="https://registry.npmjs.org/kontra/-/kontra-6.2.2.tgz">TGZ file</a></li>
 <li><a href="https://github.com/straker/kontra">Github repo</a></li>
 </ul>
 <h2 id="package-mangers">Package mangers</h2>

--- a/docs/download.html
+++ b/docs/download.html
@@ -74,7 +74,7 @@
 <li><a href="https://raw.githubusercontent.com/straker/kontra/master/kontra.js">Global object development version</a></li>
 <li><a href="https://raw.githubusercontent.com/straker/kontra/master/kontra.min.mjs">ES Module production version</a></li>
 <li><a href="https://raw.githubusercontent.com/straker/kontra/master/kontra.mjs">ES Module development version</a></li>
-<li><a href="https://registry.npmjs.org/kontra/-/kontra-6.2.0.tgz">TGZ file</a></li>
+<li>[TGZ file](<a href="https://registry.npmjs.org/kontra/-/kontra-%7B%7B">https://registry.npmjs.org/kontra/-/kontra-{{</a> packageVersion }}.tgz)</li>
 <li><a href="https://github.com/straker/kontra">Github repo</a></li>
 </ul>
 <h2 id="package-mangers">Package mangers</h2>
@@ -84,18 +84,14 @@
 </ul>
 <h2 id="cdn">CDN</h2>
 <h3 id="global-object">Global Object</h3>
-<pre><code class="lang-html">&lt;script src=&quot;https://cdn.jsdelivr.net/npm/kontra@6.2.0/kontra.min.js&quot;&gt;&lt;/script&gt;
-</code></pre>
-<pre><code class="lang-html">&lt;script src=&quot;https://cdn.jsdelivr.net/npm/kontra@6.2.0/kontra.js&quot;&gt;&lt;/script&gt;
-</code></pre>
+<pre><code class="language-html">&lt;script src=&quot;https://cdn.jsdelivr.net/npm/kontra@6.2.2/kontra.min.js&quot;&gt;&lt;/script&gt;</code></pre>
+<pre><code class="language-html">&lt;script src=&quot;https://cdn.jsdelivr.net/npm/kontra@6.2.2/kontra.js&quot;&gt;&lt;/script&gt;</code></pre>
 <h3 id="es-module-import">ES Module Import</h3>
-<pre><code class="lang-js">import kontra from &#39;https://cdn.jsdelivr.net/npm/kontra@6.2.0/kontra.min.mjs&#39;;
-</code></pre>
-<pre><code class="lang-js">import kontra from &#39;https://cdn.jsdelivr.net/npm/kontra@6.2.0/kontra.mjs&#39;;
-</code></pre>
+<pre><code class="language-js">import kontra from &#39;https://cdn.jsdelivr.net/npm/kontra@6.2.2/kontra.min.mjs&#39;;</code></pre>
+<pre><code class="language-js">import kontra from &#39;https://cdn.jsdelivr.net/npm/kontra@6.2.2/kontra.mjs&#39;;</code></pre>
 <h2 id="custom-builds">Custom Builds</h2>
 <p>As of kontra 6.0.0, custom builds can be achieved by using a module bundler such as <a href="https://rollupjs.org/">Rollup</a> or <a href="https://webpack.js.org/">webpack</a>. Kontra supports ES modules, allowing you to use <a href="https://rollupjs.org/guide/en#tree-shaking">tree-shaking</a> to only bundle the code you need.</p>
-<pre><code class="lang-js">// game.js
+<pre><code class="language-js">// game.js
 import { Sprite, GameLoop } from &#39;kontra&#39;;
 
 let sprite = Sprite({
@@ -116,10 +112,8 @@ let loop = GameLoop({
   }
 });
 
-loop.start();
-</code></pre>
-<pre><code class="lang-bash">$ rollup game.js --format iife --file game.bundle.js
-</code></pre>
+loop.start();</code></pre>
+<pre><code class="language-bash">$ rollup game.js --format iife --file game.bundle.js</code></pre>
         
 
 

--- a/docs/getting-started.html
+++ b/docs/getting-started.html
@@ -78,16 +78,13 @@
 <p>There are a few different ways to load the library depending on how you are going to use it.</p>
 <h3 id="global-object">Global Object</h3>
 <p>Load the library by adding it as a script tag. This will add a global <code>kontra</code> object to the page with all Kontra functions and properties.</p>
-<pre><code class="lang-html">&lt;script src=&quot;path/to/kontra.js&quot;&gt;&lt;/script&gt;
-</code></pre>
+<pre><code class="language-html">&lt;script src=&quot;path/to/kontra.js&quot;&gt;&lt;/script&gt;</code></pre>
 <h3 id="es-module-import">ES Module Import</h3>
 <p>Kontra also supports ES modules and exports all API functions, allowing you to import it into your code as well. Import the file <code>kontra.mjs</code> and either use the entire <code>kontra</code> object or just import the functions you need.</p>
-<pre><code class="lang-js">import kontra from &#39;path/to/kontra.mjs&#39;;
-</code></pre>
+<pre><code class="language-js">import kontra from &#39;path/to/kontra.mjs&#39;;</code></pre>
 <h3 id="module-bundler">Module Bundler</h3>
 <p>If you&#39;re using a module bundler that supports npm dependency resolution (such as Webpack or Parcel), you can import the library directly from the module name. This is the recommended way to create <a href="download">custom builds</a> of the library.</p>
-<pre><code class="lang-js">import kontra from &#39;kontra&#39;;
-</code></pre>
+<pre><code class="language-js">import kontra from &#39;kontra&#39;;</code></pre>
 <h3 id="web-maker">Web Maker</h3>
 <p>Want to get started without all the hassle? <a href="https://webmakerapp.com/">Web Maker</a> has you covered! When you start a new project, select the Kontra Game Engine from the list of predefined templates and you&#39;re good to go. Learn more by reading the <a href="https://medium.com/web-maker/js13kgames-jam-with-web-maker-a3389cf2cbb">Web Maker and JS13k tutorial</a>.</p>
 <h2 id="initialize">Initialize</h2>
@@ -106,37 +103,34 @@
     </li>
     <li role="presentation"></li>
   </ul>
-  <section role="tabpanel" aria-labelledby=getting-started-global-tab data-tabpanel="global"><pre><code class="lang-js">let { init } = kontra;
+  <section role="tabpanel" aria-labelledby=getting-started-global-tab data-tabpanel="global"><pre><code class="language-js">let { init } = kontra;
 
-let { canvas, context } = init();
-</code></pre></section>
-  <section role="tabpanel" aria-labelledby=getting-started-es-tab data-tabpanel="es"><pre><code class="lang-js">import { init } from 'path/to/kontra.mjs';
+let { canvas, context } = init();</code></pre></section>
+  <section role="tabpanel" aria-labelledby=getting-started-es-tab data-tabpanel="es"><pre><code class="language-js">import { init } from 'path/to/kontra.mjs';
 
-let { canvas, context } = init();
-</code></pre></section>
-  <section role="tabpanel" aria-labelledby=getting-started-bundle-tab data-tabpanel="bundle"><pre><code class="lang-js">import { init } from &#39;kontra&#39;;
+let { canvas, context } = init();</code></pre></section>
+  <section role="tabpanel" aria-labelledby=getting-started-bundle-tab data-tabpanel="bundle"><pre><code class="language-js">import { init } from &#39;kontra&#39;;
 
-let { canvas, context } = init();
-</code></pre></section>
+let { canvas, context } = init();</code></pre></section>
 </div>
 <h2 id="create">Create</h2>
 <p>After the game is initialize, you can create a simple <a href="api/sprite.html">Sprite</a> and <a href="api/gameLoop.html">Game Loop</a> in just a few lines of code</p>
-<canvas id="game-canvas-8"></canvas>
+<canvas id="game-canvas-1"></canvas>
 
 <div class="tablist">
   <ul role="tablist">
     <li role="presentation" data-tab="global">
-      <button role="tab" id="game-canvas-8-global-tab">Global Object</button>
+      <button role="tab" id="game-canvas-1-global-tab">Global Object</button>
     </li>
     <li role="presentation" data-tab="es">
-      <button role="tab" id="game-canvas-8-es-tab">ES Module Import</button>
+      <button role="tab" id="game-canvas-1-es-tab">ES Module Import</button>
     </li>
     <li role="presentation" data-tab="bundle">
-      <button role="tab" id="game-canvas-8-bundle-tab">Module Bundler</button>
+      <button role="tab" id="game-canvas-1-bundle-tab">Module Bundler</button>
     </li>
     <li role="presentation"></li>
   </ul>
-  <section role="tabpanel" aria-labelledby=game-canvas-8-global-tab data-tabpanel="global">
+  <section role="tabpanel" aria-labelledby=game-canvas-1-global-tab data-tabpanel="global">
     <pre><code class="lang-js">let { init, Sprite, GameLoop } &#x3D; kontra
 
 let { canvas } &#x3D; init();
@@ -167,7 +161,7 @@ let loop &#x3D; GameLoop({  // create the main game loop
 
 loop.start();    // start the game</code></pre>
   </section>
-  <section role="tabpanel" aria-labelledby=game-canvas-8-es-tab data-tabpanel="es">
+  <section role="tabpanel" aria-labelledby=game-canvas-1-es-tab data-tabpanel="es">
     <pre><code class="lang-js">import { init, Sprite, GameLoop } from &#x27;path/to/kontra.mjs&#x27;
 
 let { canvas } &#x3D; init();
@@ -198,7 +192,7 @@ let loop &#x3D; GameLoop({  // create the main game loop
 
 loop.start();    // start the game</code></pre>
   </section>
-  <section role="tabpanel" aria-labelledby=game-canvas-8-bundle-tab data-tabpanel="bundle">
+  <section role="tabpanel" aria-labelledby=game-canvas-1-bundle-tab data-tabpanel="bundle">
     <pre><code class="lang-js">import { init, Sprite, GameLoop } from &#x27;kontra&#x27;;
 
 let { canvas } &#x3D; init();
@@ -232,8 +226,8 @@ loop.start();    // start the game</code></pre>
 </div>
 
 <script>(function() {
-  kontra.init("game-canvas-8");
-  var canvas = document.querySelector("#game-canvas-8");
+  kontra.init("game-canvas-1");
+  var canvas = document.querySelector("#game-canvas-1");
   canvas.width = 600;
   canvas.height = 200;
   var context = canvas.getContext("2d");

--- a/docs/getting-started.html
+++ b/docs/getting-started.html
@@ -115,22 +115,22 @@ let { canvas, context } = init();</code></pre></section>
 </div>
 <h2 id="create">Create</h2>
 <p>After the game is initialize, you can create a simple <a href="api/sprite.html">Sprite</a> and <a href="api/gameLoop.html">Game Loop</a> in just a few lines of code</p>
-<canvas id="game-canvas-1"></canvas>
+<canvas id="game-canvas-8"></canvas>
 
 <div class="tablist">
   <ul role="tablist">
     <li role="presentation" data-tab="global">
-      <button role="tab" id="game-canvas-1-global-tab">Global Object</button>
+      <button role="tab" id="game-canvas-8-global-tab">Global Object</button>
     </li>
     <li role="presentation" data-tab="es">
-      <button role="tab" id="game-canvas-1-es-tab">ES Module Import</button>
+      <button role="tab" id="game-canvas-8-es-tab">ES Module Import</button>
     </li>
     <li role="presentation" data-tab="bundle">
-      <button role="tab" id="game-canvas-1-bundle-tab">Module Bundler</button>
+      <button role="tab" id="game-canvas-8-bundle-tab">Module Bundler</button>
     </li>
     <li role="presentation"></li>
   </ul>
-  <section role="tabpanel" aria-labelledby=game-canvas-1-global-tab data-tabpanel="global">
+  <section role="tabpanel" aria-labelledby=game-canvas-8-global-tab data-tabpanel="global">
     <pre><code class="lang-js">let { init, Sprite, GameLoop } &#x3D; kontra
 
 let { canvas } &#x3D; init();
@@ -161,7 +161,7 @@ let loop &#x3D; GameLoop({  // create the main game loop
 
 loop.start();    // start the game</code></pre>
   </section>
-  <section role="tabpanel" aria-labelledby=game-canvas-1-es-tab data-tabpanel="es">
+  <section role="tabpanel" aria-labelledby=game-canvas-8-es-tab data-tabpanel="es">
     <pre><code class="lang-js">import { init, Sprite, GameLoop } from &#x27;path/to/kontra.mjs&#x27;
 
 let { canvas } &#x3D; init();
@@ -192,7 +192,7 @@ let loop &#x3D; GameLoop({  // create the main game loop
 
 loop.start();    // start the game</code></pre>
   </section>
-  <section role="tabpanel" aria-labelledby=game-canvas-1-bundle-tab data-tabpanel="bundle">
+  <section role="tabpanel" aria-labelledby=game-canvas-8-bundle-tab data-tabpanel="bundle">
     <pre><code class="lang-js">import { init, Sprite, GameLoop } from &#x27;kontra&#x27;;
 
 let { canvas } &#x3D; init();
@@ -226,8 +226,8 @@ loop.start();    // start the game</code></pre>
 </div>
 
 <script>(function() {
-  kontra.init("game-canvas-1");
-  var canvas = document.querySelector("#game-canvas-1");
+  kontra.init("game-canvas-8");
+  var canvas = document.querySelector("#game-canvas-8");
   canvas.width = 600;
   canvas.height = 200;
   var context = canvas.getContext("2d");

--- a/docs/index.html
+++ b/docs/index.html
@@ -90,7 +90,7 @@
 <li>Prototyping.</li>
 <li>Game jams.</li>
 </ul>
-<h2 id="ready-to-get-going-">Ready to Get Going?</h2>
+<h2 id="ready-to-get-going">Ready to Get Going?</h2>
 <ul>
 <li>Read the <a href="getting-started">getting started guide</a> and some <a href="tutorials">tutorials</a>.</li>
 <li>Look at <a href="made-with-kontra">games made with Kontra</a>.</li>

--- a/docs/made-with-kontra.html
+++ b/docs/made-with-kontra.html
@@ -122,7 +122,7 @@
  <a href="https://js13kgames.com/entries/they-follow">
    <img src="assets/imgs/games/they-follow.jpg" alt="" width="320" height="200"/>
    <span>They Follow</span>
-   <span><span class="visually-hidden">. By </span><small>Tero &amp; Sami</small></span>
+   <span><span class="visually-hidden">. By </span><small>Tero & Sami</small></span>
  </a>
 </li>
 

--- a/docs/pages/download.js
+++ b/docs/pages/download.js
@@ -8,7 +8,7 @@ Download the latest version of Kontra.
 - [Global object development version](https://raw.githubusercontent.com/straker/kontra/master/kontra.js)
 - [ES Module production version](https://raw.githubusercontent.com/straker/kontra/master/kontra.min.mjs)
 - [ES Module development version](https://raw.githubusercontent.com/straker/kontra/master/kontra.mjs)
-- [TGZ file](https://registry.npmjs.org/kontra/-/kontra-{{ packageVersion }}.tgz)
+- [TGZ file](https://registry.npmjs.org/kontra/-/kontra-__packageVersion__.tgz)
 - [Github repo](https://github.com/straker/kontra)
 
 ## Package mangers
@@ -21,21 +21,21 @@ Download the latest version of Kontra.
 ### Global Object
 
 ```html
-<script src="https://cdn.jsdelivr.net/npm/kontra@{{ packageVersion }}/kontra.min.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/kontra@__packageVersion__/kontra.min.js"></script>
 ```
 ```html
-<script src="https://cdn.jsdelivr.net/npm/kontra@{{ packageVersion }}/kontra.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/kontra@__packageVersion__/kontra.js"></script>
 ```
 
 ### ES Module Import
 
 ```js
 // exclude-tablist
-import kontra from 'https://cdn.jsdelivr.net/npm/kontra@{{ packageVersion }}/kontra.min.mjs';
+import kontra from 'https://cdn.jsdelivr.net/npm/kontra@__packageVersion__/kontra.min.mjs';
 ```
 ```js
 // exclude-tablist
-import kontra from 'https://cdn.jsdelivr.net/npm/kontra@{{ packageVersion }}/kontra.mjs';
+import kontra from 'https://cdn.jsdelivr.net/npm/kontra@__packageVersion__/kontra.mjs';
 ```
 
 ## Custom Builds


### PR DESCRIPTION
`marked` v0.7.0 changed the classname of code from `lang-js` to `language-js`, which broke the code for the import tablist switcher output.