### PR TITLE
fix(vector): keep clamp settings after adding two vectors

### DIFF
--- a/src/vector.js
+++ b/src/vector.js
@@ -12,9 +12,9 @@
  * @param {Number} [y=0] - Y coordinate of the vector.
  */
 class Vector {
-  constructor(x, y) {
-    this._x = x || 0;
-    this._y = y || 0;
+  constructor(x = 0, y = 0) {
+    this._x = x;
+    this._y = y;
   }
 
   /**
@@ -27,10 +27,11 @@ class Vector {
    *
    * @returns {kontra.Vector} A new kontra.Vector instance.
    */
-  add(vec, dt) {
+  add(vec, dt = 1) {
     return vectorFactory(
-      this.x + (vec.x || 0) * (dt || 1),
-      this.y + (vec.y || 0) * (dt || 1)
+      this.x + (vec.x || 0) * dt,
+      this.y + (vec.y || 0) * dt,
+      this
     );
   }
 
@@ -95,8 +96,19 @@ class Vector {
   }
 }
 
-export default function vectorFactory(x, y) {
-  return new Vector(x, y);
+export default function vectorFactory(x, y, vec = {}) {
+  let vector = new Vector(x, y);
+
+  // preserve vector clamping when creating new vectors
+  if (vec._c) {
+    vector.clamp(vec._a, vec._b, vec._d, vec._e);
+
+    // enforce clamping on setting
+    vector.x = x;
+    vector.y = y;
+  }
+
+  return vector;
 }
 vectorFactory.prototype = Vector.prototype;
 vectorFactory.class = Vector;

--- a/src/vector.js
+++ b/src/vector.js
@@ -103,7 +103,7 @@ export default function vectorFactory(x, y, vec = {}) {
   if (vec._c) {
     vector.clamp(vec._a, vec._b, vec._d, vec._e);
 
-    // enforce clamping on setting
+    // reset x and y so clamping takes effect
     vector.x = x;
     vector.y = y;
   }

--- a/test/unit/vector.spec.js
+++ b/test/unit/vector.spec.js
@@ -98,6 +98,13 @@ describe('vector', () => {
       expect(vector.y).to.equal(75);
     });
 
+    it.only('should preserve clamp settings when adding vectors', () => {
+      let vec = vector.add(Vector(100, 100));
+
+      expect(vec.x).to.equal(50);
+      expect(vec.y).to.equal(75);
+    });
+
   });
 
 });

--- a/test/unit/vector.spec.js
+++ b/test/unit/vector.spec.js
@@ -98,7 +98,7 @@ describe('vector', () => {
       expect(vector.y).to.equal(75);
     });
 
-    it.only('should preserve clamp settings when adding vectors', () => {
+    it('should preserve clamp settings when adding vectors', () => {
       let vec = vector.add(Vector(100, 100));
 
       expect(vec.x).to.equal(50);


### PR DESCRIPTION
Closes #83 