### PR TITLE
Use temporary image for tileEngine renders

### DIFF
--- a/src/tileEngine.js
+++ b/src/tileEngine.js
@@ -541,13 +541,12 @@ export default function TileEngine(properties = {}) {
    */
   function render(canvas) {
     const { width, height } = getCanvas();
-    const image = new Image();
-    
-    image.src=canvas.toDataURL();
-    
+    const sWidth = Math.min(canvas.width, width);
+    const sHeight = Math.min(canvas.height, height);
+
     tileEngine.context.drawImage(
-      image,
-      tileEngine.sx, tileEngine.sy, width, height,
+      canvas,
+      tileEngine.sx, tileEngine.sy, sWidth, sHeight,
       0, 0, width, height
     );
   }

--- a/src/tileEngine.js
+++ b/src/tileEngine.js
@@ -540,9 +540,13 @@ export default function TileEngine(properties = {}) {
    * @param {HTMLCanvasElement} canvas - Tile engine canvas to draw.
    */
   function render(canvas) {
-    let { width, height } = getCanvas();
+    const { width, height } = getCanvas();
+    const image = new Image();
+    
+    image.src=canvas.toDataURL();
+    
     tileEngine.context.drawImage(
-      canvas,
+      image,
       tileEngine.sx, tileEngine.sy, width, height,
       0, 0, width, height
     );

--- a/src/tileEngine.js
+++ b/src/tileEngine.js
@@ -547,7 +547,7 @@ export default function TileEngine(properties = {}) {
     tileEngine.context.drawImage(
       canvas,
       tileEngine.sx, tileEngine.sy, sWidth, sHeight,
-      0, 0, width, height
+      0, 0, sWidth, sHeight
     );
   }
 

--- a/test/unit/tileEngine.spec.js
+++ b/test/unit/tileEngine.spec.js
@@ -321,15 +321,12 @@ describe('tileEngine', () => {
       sinon.stub(context, 'drawImage').callsFake(noop);
       tileEngine.renderLayer('test');
 
-      const img = new Image()
-      img.src = tileEngine.layerCanvases.test.toDataURL()
-
       expect(context.drawImage.called).to.be.ok;
-      expect(context.drawImage.firstCall.args[0]).to.deep.equal(img);
-      expect(context.drawImage.firstCall.args.slice(1)).to.deep.equal([
-        0, 0, canvas.width, canvas.height,
+      expect(context.drawImage.calledWith(
+        tileEngine.layerCanvases.test,
+        0, 0, tileEngine.layerCanvases.test.width, tileEngine.layerCanvases.test.height,
         0, 0, canvas.width, canvas.height
-      ]);
+      )).to.be.ok;
 
       context.drawImage.restore();
     });
@@ -374,11 +371,12 @@ describe('tileEngine', () => {
       img.src = tileEngine.layerCanvases.test.toDataURL()
 
       expect(context.drawImage.called).to.be.ok;
-      expect(context.drawImage.firstCall.args[0]).to.deep.equal(img);
-      expect(context.drawImage.firstCall.args.slice(1)).to.deep.equal([
-        tileEngine.sx, tileEngine.sy, canvas.width, canvas.height,
+      expect(context.drawImage.calledWith(
+        tileEngine.layerCanvases.test,
+        tileEngine.sx, tileEngine.sy, tileEngine.layerCanvases.test.width,
+        tileEngine.layerCanvases.test.height,
         0, 0, canvas.width, canvas.height
-      ])
+      )).to.be.ok;
 
       context.drawImage.restore();
     });

--- a/test/unit/tileEngine.spec.js
+++ b/test/unit/tileEngine.spec.js
@@ -321,12 +321,15 @@ describe('tileEngine', () => {
       sinon.stub(context, 'drawImage').callsFake(noop);
       tileEngine.renderLayer('test');
 
+      const img = new Image()
+      img.src = tileEngine.layerCanvases.test.toDataURL()
+
       expect(context.drawImage.called).to.be.ok;
-      expect(context.drawImage.calledWith(
-        tileEngine.layerCanvases.test,
+      expect(context.drawImage.firstCall.args[0]).to.deep.equal(img);
+      expect(context.drawImage.firstCall.args.slice(1)).to.deep.equal([
         0, 0, canvas.width, canvas.height,
         0, 0, canvas.width, canvas.height
-      )).to.be.ok;
+      ]);
 
       context.drawImage.restore();
     });
@@ -367,12 +370,15 @@ describe('tileEngine', () => {
 
       tileEngine.renderLayer('test');
 
+      const img = new Image()
+      img.src = tileEngine.layerCanvases.test.toDataURL()
+
       expect(context.drawImage.called).to.be.ok;
-      expect(context.drawImage.calledWith(
-        tileEngine.layerCanvases.test,
+      expect(context.drawImage.firstCall.args[0]).to.deep.equal(img);
+      expect(context.drawImage.firstCall.args.slice(1)).to.deep.equal([
         tileEngine.sx, tileEngine.sy, canvas.width, canvas.height,
         0, 0, canvas.width, canvas.height
-      )).to.be.ok;
+      ])
 
       context.drawImage.restore();
     });

--- a/test/unit/tileEngine.spec.js
+++ b/test/unit/tileEngine.spec.js
@@ -325,7 +325,7 @@ describe('tileEngine', () => {
       expect(context.drawImage.calledWith(
         tileEngine.layerCanvases.test,
         0, 0, tileEngine.layerCanvases.test.width, tileEngine.layerCanvases.test.height,
-        0, 0, canvas.width, canvas.height
+        0, 0, tileEngine.layerCanvases.test.width, tileEngine.layerCanvases.test.height
       )).to.be.ok;
 
       context.drawImage.restore();
@@ -373,9 +373,9 @@ describe('tileEngine', () => {
       expect(context.drawImage.called).to.be.ok;
       expect(context.drawImage.calledWith(
         tileEngine.layerCanvases.test,
-        tileEngine.sx, tileEngine.sy, tileEngine.layerCanvases.test.width,
-        tileEngine.layerCanvases.test.height,
-        0, 0, canvas.width, canvas.height
+        tileEngine.sx, tileEngine.sy,
+        tileEngine.layerCanvases.test.width, tileEngine.layerCanvases.test.height,
+        0, 0, tileEngine.layerCanvases.test.width, tileEngine.layerCanvases.test.height
       )).to.be.ok;
 
       context.drawImage.restore();


### PR DESCRIPTION
On Safari 12.1.2 copying the offscreenCanvas into the real canvas doesn't seem to work. The offscreenCanvas is created correctly (as can be seen through the canvas debug tool) but when the render function is drawing the image that is in it, it has no effect. Creating a new image with the content of the offscreenCanvas and using that one instead seems to fix the problem.