### PR TITLE
Pool Improvements

### DIFF
--- a/src/pool.js
+++ b/src/pool.js
@@ -124,15 +124,6 @@ class Pool {
   }
 
   /**
-   * Sort utility function for update. Sorts dead objects to the end of the array.
-   * @memberof Pool
-   * @function _sfn
-   */
-  _sfn(a, b) {
-    return b.isAlive() - a.isAlive();
-  }
-
-  /**
    * Update all alive objects in the pool by calling the objects `update()` function. This function also manages when each object should be recycled, so it is recommended that you do not call the objects `update()` function outside of this function.
    * @memberof Pool
    * @function update
@@ -142,7 +133,6 @@ class Pool {
   update(dt) {
     let obj;
     let doSort = false;
-    let oldSize = this.size;
     for (let i = this.size; i--; ) {
       obj = this.objects[i];
 
@@ -155,9 +145,7 @@ class Pool {
     }
     // sort all dead elements to the end of the pool
     if (doSort) {
-      let front = this.objects.slice(0, oldSize);
-      front.sort(this._sfn);
-      this.objects = front.concat(this.objects.slice(oldSize));
+      this.objects.sort((a, b) => b.isAlive() - a.isAlive());
     }
   }
 

--- a/src/pool.js
+++ b/src/pool.js
@@ -29,9 +29,8 @@ class Pool {
     }
     // @endif
 
-    // c = create, i = inUse
+    // c = create
     this._c = create;
-    this._i = 0;
 
     /**
      * All objects currently in the pool, both alive and not alive.
@@ -45,7 +44,7 @@ class Pool {
      * @memberof Pool
      * @property {Number} size
      */
-    this.size = 1;
+    this.size = 0;
 
     /**
      * The maximum number of objects allowed in the pool. The pool will never grow beyond this size.
@@ -84,26 +83,26 @@ class Pool {
    */
   get(properties = {}) {
     // the pool is out of objects if the first object is in use and it can't grow
-    if (this.objects.length == this._i) {
+    if (this.size === this.objects.length) {
       if (this.size === this.maxSize) {
         return;
       }
-      // double the size of the array by filling it with twice as many objects
+      // double the size of the array by adding twice as many new objects to the end
       else {
-        for (let x = 0; x < this.size && this.objects.length < this.maxSize; x++) {
-          this.objects.unshift(this._c());
+        for (let i = 0; i < this.size; i++) {
+          this.objects.push(this._c());
+          if (this.objects.length === this.maxSize) {
+            break;
+          }
         }
-
-        this.size = this.objects.length;
       }
     }
 
     // save off first object in pool to reassign to last object after unshift
-    let obj = this.objects.shift();
+    let obj = this.objects[this.size];
+    this.size++;
     obj.init(properties);
-    this.objects.push(obj);
-    this._i++;
-    return obj
+    return obj;
   }
 
   /**
@@ -114,7 +113,7 @@ class Pool {
    * @returns {Object[]} An Array of all alive objects.
    */
   getAliveObjects() {
-    return this.objects.slice(this.objects.length - this._i);
+    return this.objects.slice(0, this.size);
   }
 
   /**
@@ -123,8 +122,7 @@ class Pool {
    * @function clear
    */
   clear() {
-    this._i = this.objects.length = 0;
-    this.size = 1;
+    this.size = this.objects.length = 0;
     this.objects.push(this._c());
   }
 
@@ -136,38 +134,21 @@ class Pool {
    * @param {Number} [dt] - Time since last update.
    */
   update(dt) {
-    let i = this.size - 1;
     let obj;
-
-    // If the user kills an object outside of the update cycle, the pool won't know of
-    // the change until the next update and this._i won't be decremented. If the user then
-    // gets an object when this._i is the same size as objects.length, this._i will increment
-    // and this statement will evaluate to -1.
-    //
-    // I don't like having to go through the pool to kill an object as it forces you to
-    // know which object came from which pool. Instead, we'll just prevent the index from
-    // going below 0 and accept the fact that this._i may be out of sync for a frame.
-    let index = Math.max(this.objects.length - this._i, 0);
-
-    // only iterate over the objects that are alive
     let doSort = false;
-    while (i >= index) {
+    for (let i = this.size; i--; ) {
       obj = this.objects[i];
 
       obj.update(dt);
 
       if (!obj.isAlive()) {
         doSort = true;
-        this._i--;
+        this.size--;
       }
-      else {
-        i--;
-      }
-
-      // if the object is dead, move it to the front of the pool
-      if (doSort) {
-        this.objects.sort((a, b) => a.isAlive() - b.isAlive());
-      }
+    }
+    // sort all dead elements to the end of the pool
+    if (doSort) {
+      this.objects.sort((a, b) => b.isAlive() - a.isAlive());
     }
   }
 
@@ -177,14 +158,11 @@ class Pool {
    * @function render
    */
   render() {
-    let index = Math.max(this.objects.length - this._i, 0);
-
-    for (let i = this.size - 1; i >= index; i--) {
+    for (let i = this.size; i--; ) {
       this.objects[i].render();
     }
   }
 }
-
 
 export default function poolFactory(properties) {
   return new Pool(properties);

--- a/src/pool.js
+++ b/src/pool.js
@@ -126,8 +126,13 @@ class Pool {
     this.objects.push(this._c());
   }
 
-  sortFn(a, b) {
-    return b.isAlive() - a.isAlive()
+  /**
+   * Sort utility function for update. Sorts dead objects to the end of the array.
+   * @memberof Pool
+   * @function _sfn
+   */
+  _sfn(a, b) {
+    return b.isAlive() - a.isAlive();
   }
 
   /**
@@ -154,7 +159,7 @@ class Pool {
     // sort all dead elements to the end of the pool
     if (doSort) {
       let front = this.objects.slice(0, oldSize);
-      front.sort(sortFn);
+      front.sort(this._sfn);
       this.objects = front.concat(this.objects.slice(oldSize));
     }
   }

--- a/src/pool.js
+++ b/src/pool.js
@@ -89,11 +89,8 @@ class Pool {
       }
       // double the size of the array by adding twice as many new objects to the end
       else {
-        for (let i = 0; i < this.size; i++) {
+        for (let i = 0; i < this.size && this.objects.length < this.maxSize; i++) {
           this.objects.push(this._c());
-          if (this.objects.length === this.maxSize) {
-            break;
-          }
         }
       }
     }

--- a/src/pool.js
+++ b/src/pool.js
@@ -126,6 +126,10 @@ class Pool {
     this.objects.push(this._c());
   }
 
+  sortFn(a, b) {
+    return b.isAlive() - a.isAlive()
+  }
+
   /**
    * Update all alive objects in the pool by calling the objects `update()` function. This function also manages when each object should be recycled, so it is recommended that you do not call the objects `update()` function outside of this function.
    * @memberof Pool
@@ -136,6 +140,7 @@ class Pool {
   update(dt) {
     let obj;
     let doSort = false;
+    let oldSize = this.size;
     for (let i = this.size; i--; ) {
       obj = this.objects[i];
 
@@ -148,7 +153,9 @@ class Pool {
     }
     // sort all dead elements to the end of the pool
     if (doSort) {
-      this.objects.sort((a, b) => b.isAlive() - a.isAlive());
+      let front = this.objects.slice(0, oldSize);
+      front.sort(sortFn);
+      this.objects = front.concat(this.objects.slice(oldSize));
     }
   }
 

--- a/src/pool.js
+++ b/src/pool.js
@@ -150,19 +150,23 @@ class Pool {
     let index = Math.max(this.objects.length - this._i, 0);
 
     // only iterate over the objects that are alive
+    let doSort = false;
     while (i >= index) {
       obj = this.objects[i];
 
       obj.update(dt);
 
-      // if the object is dead, move it to the front of the pool
       if (!obj.isAlive()) {
-        this.objects = this.objects.splice(i, 1).concat(this.objects);
+        doSort = true;
         this._i--;
-        index++;
       }
       else {
         i--;
+      }
+
+      // if the object is dead, move it to the front of the pool
+      if (doSort) {
+        this.objects.sort((a, b) => a.isAlive() - b.isAlive());
       }
     }
   }

--- a/test/unit/pool.spec.js
+++ b/test/unit/pool.spec.js
@@ -110,44 +110,6 @@ describe('pool', () => {
       expect(spy.calledWith(args)).to.be.ok;
     });
 
-    it('should use the first object in the pool and move it to the back of the pool', () => {
-      let pool = Pool({
-        create: sprite,
-        maxSize: 5,
-      });
-
-      // fill the pool
-      pool.get({alive: true});
-      pool.get({alive: true});
-      pool.get({alive: true});
-      pool.get({alive: true});
-      pool.get({alive: true});
-
-      // kill objects in the pool
-      for (let i = 0; i < 5; i++) {
-        pool.objects[i].alive = false;
-      }
-
-      // update pool position
-      pool.update();
-
-      let expected = [
-        pool.objects[1],
-        pool.objects[2],
-        pool.objects[3],
-        pool.objects[4],
-        pool.objects[0]
-      ]
-
-      pool.get();
-
-      expect(pool.objects[0]).to.equal(expected[0]);
-      expect(pool.objects[1]).to.equal(expected[1]);
-      expect(pool.objects[2]).to.equal(expected[2]);
-      expect(pool.objects[3]).to.equal(expected[3]);
-      expect(pool.objects[4]).to.equal(expected[4]);
-    });
-
     it('should increase the size of the pool when there are no more objects', () => {
       let pool = Pool({
         create: sprite

--- a/test/unit/pool.spec.js
+++ b/test/unit/pool.spec.js
@@ -153,13 +153,13 @@ describe('pool', () => {
         create: sprite
       });
 
-      expect(pool.size).to.equal(1);
+      expect(pool.size).to.equal(0);
 
       pool.get({alive: true});
       pool.get({alive: true});
       pool.get({alive: true});
 
-      expect(pool.size).to.not.equal(1);
+      expect(pool.size).to.not.equal(0);
     });
 
     it('should not increase the size of the pool past the max size', () => {
@@ -188,7 +188,7 @@ describe('pool', () => {
       }
 
       expect(pool.size).to.not.equal(pool.maxSize);
-      expect(pool.size).to.be.equal(256);
+      expect(pool.objects.length).to.be.equal(256);
     });
 
   });
@@ -279,7 +279,7 @@ describe('pool', () => {
       expect(count).to.equal(3);
     });
 
-    it('should move a dead object to the front of the pool', () => {
+    it('should move a dead object to the end of the pool', () => {
       let pool = Pool({
         create: sprite,
         maxSize: 5
@@ -291,11 +291,11 @@ describe('pool', () => {
       pool.objects[2].ttl = 1;
 
       let expected = [
-        pool.objects[2],
         pool.objects[0],
         pool.objects[1],
         pool.objects[3],
-        pool.objects[4]
+        pool.objects[4],
+        pool.objects[2]
       ];
 
       expect(pool.objects[0].isAlive()).to.be.true;
@@ -303,8 +303,9 @@ describe('pool', () => {
       pool.update();
 
       expect(pool.getAliveObjects().length).to.equal(4);
-      expect(pool.objects[0].isAlive()).to.be.false;
-      expect(pool.getAliveObjects().indexOf(pool.objects[0])).to.equal(-1);
+      expect(pool.objects[2].isAlive()).to.be.true;
+      expect(pool.objects[4].isAlive()).to.be.false;
+      expect(pool.getAliveObjects().indexOf(pool.objects[4])).to.equal(-1);
 
       expect(pool.objects[0]).to.equal(expected[0]);
       expect(pool.objects[1]).to.equal(expected[1]);
@@ -374,7 +375,7 @@ describe('pool', () => {
       pool.clear();
 
       expect(pool.objects.length).to.equal(1);
-      expect(pool.size).to.equal(1);
+      expect(pool.size).to.equal(0);
     });
 
   });


### PR DESCRIPTION
I refactored Pool a little to improve performance and usability.

## 1. Useful `.size`

The biggest change is that alive objects are now at the front of the pool. This simplifies the logic in various ways. Most disruptively by removing `_i` and using `size` instead. This changes `size` from how large the pool's array is to how many items are currently alive and stored in the pool. 

## 2. Sorting instead of hot splicing

In `update()`, each item that was found to be dead was spliced to the front immediately. After running a few performance tests, I've replaced it with a system that sorts the pool at the end of `update()` if needed. A few more tests led me to believe that sorting only the alive part of the array was also faster (especially in mostly empty pools) so that's what I've done.

## Known Issues

This is currently failing a test. Not wanting to just remove tests to match the new code, I left one that seems to be describing the old internals. Please advise!