### PR TITLE
Fix anchor URLs in documentation

### DIFF
--- a/docs/api/animation.html
+++ b/docs/api/animation.html
@@ -293,7 +293,7 @@ image.onload = function() {
             </a>
           </h2>
 
-          <p>The height of an individual frame. Taken from the property of the same name in the <a href="api/animation/#spriteSheet">spriteSheet</a>.</p>
+          <p>The height of an individual frame. Taken from the property of the same name in the <a href="api/animation#spriteSheet">spriteSheet</a>.</p>
           
         </section>
         <section>
@@ -315,7 +315,7 @@ image.onload = function() {
             </a>
           </h2>
 
-          <p>The space between each frame. Taken from the property of the same name in the <a href="api/animation/#spriteSheet">spriteSheet</a>.</p>
+          <p>The space between each frame. Taken from the property of the same name in the <a href="api/animation#spriteSheet">spriteSheet</a>.</p>
           
         </section>
         <section>
@@ -418,7 +418,7 @@ image.onload = function() {
             </a>
           </h2>
 
-          <p>The width of an individual frame. Taken from the property of the same name in the <a href="api/animation/#spriteSheet">spriteSheet</a>.</p>
+          <p>The width of an individual frame. Taken from the property of the same name in the <a href="api/animation#spriteSheet">spriteSheet</a>.</p>
           
         </section>
 

--- a/docs/api/assets.html
+++ b/docs/api/assets.html
@@ -219,7 +219,7 @@ load(
             </a>
           </h2>
 
-          <p>Object of all loaded audio assets by both file name and path. If the base <a href="api/assets/#setAudioPath">audio path</a> was set before the audio was loaded, the file name and path will not include the base audio path.</p>
+          <p>Object of all loaded audio assets by both file name and path. If the base <a href="api/assets#setAudioPath">audio path</a> was set before the audio was loaded, the file name and path will not include the base audio path.</p>
 <div class="tablist">
   <ul role="tablist">
     <li role="presentation" data-tab="global">
@@ -286,7 +286,7 @@ load(&#39;sound.ogg&#39;).then(function() {
             </a>
           </h2>
 
-          <p>Object of all loaded data assets by both file name and path. If the base <a href="api/assets/#setDataPath">data path</a> was set before the data was loaded, the file name and path will not include the base data path.</p>
+          <p>Object of all loaded data assets by both file name and path. If the base <a href="api/assets#setDataPath">data path</a> was set before the data was loaded, the file name and path will not include the base data path.</p>
 <div class="tablist">
   <ul role="tablist">
     <li role="presentation" data-tab="global">
@@ -353,7 +353,7 @@ load(&#39;info.json&#39;).then(function() {
             </a>
           </h2>
 
-          <p>Object of all loaded image assets by both file name and path. If the base <a href="api/assets/#setImagePath">image path</a> was set before the image was loaded, the file name and path will not include the base image path.</p>
+          <p>Object of all loaded image assets by both file name and path. If the base <a href="api/assets#setImagePath">image path</a> was set before the image was loaded, the file name and path will not include the base image path.</p>
 <div class="tablist">
   <ul role="tablist">
     <li role="presentation" data-tab="global">
@@ -420,7 +420,7 @@ load(&#39;character_walk_sheet.png&#39;).then(function() {
             </a>
           </h2>
 
-          <p>Load Image, Audio, or data files. Uses the <a href="api/assets/#loadImage">loadImage</a>, <a href="api/assets/#loadAudio">loadAudio</a>, and <a href="api/assets/#loadData">loadData</a> functions to load each asset type.</p>
+          <p>Load Image, Audio, or data files. Uses the <a href="api/assets#loadImage">loadImage</a>, <a href="api/assets#loadAudio">loadAudio</a>, and <a href="api/assets#loadData">loadData</a> functions to load each asset type.</p>
 <div class="tablist">
   <ul role="tablist">
     <li role="presentation" data-tab="global">
@@ -490,8 +490,8 @@ load(
             </a>
           </h2>
 
-          <p>Load a single Audio asset. Supports loading multiple audio formats which the loader will use to load the first audio format supported by the browser in the order listed. Uses the base <a href="api/assets/#setAudioPath">audio path</a> to resolve the URL.</p>
-<p>Once loaded, the asset will be accessible on the the <a href="api/assets/#audioAssets">audioAssets</a> property. Since the loader determines which audio asset to load based on browser support, you should only reference the audio by its name and not by its file path since there&#39;s no guarantee which asset was loaded.</p>
+          <p>Load a single Audio asset. Supports loading multiple audio formats which the loader will use to load the first audio format supported by the browser in the order listed. Uses the base <a href="api/assets#setAudioPath">audio path</a> to resolve the URL.</p>
+<p>Once loaded, the asset will be accessible on the the <a href="api/assets#audioAssets">audioAssets</a> property. Since the loader determines which audio asset to load based on browser support, you should only reference the audio by its name and not by its file path since there&#39;s no guarantee which asset was loaded.</p>
 <div class="tablist">
   <ul role="tablist">
     <li role="presentation" data-tab="global">
@@ -558,8 +558,8 @@ loadAudio([
             </a>
           </h2>
 
-          <p>Load a single Data asset. Uses the base <a href="api/assets/#setDataPath">data path</a> to resolve the URL.</p>
-<p>Once loaded, the asset will be accessible on the the <a href="api/assets/#dataAssets">dataAssets</a> property.</p>
+          <p>Load a single Data asset. Uses the base <a href="api/assets#setDataPath">data path</a> to resolve the URL.</p>
+<p>Once loaded, the asset will be accessible on the the <a href="api/assets#dataAssets">dataAssets</a> property.</p>
 <div class="tablist">
   <ul role="tablist">
     <li role="presentation" data-tab="global">
@@ -611,8 +611,8 @@ loadData(&#39;assets/data/tile_engine_basic.json&#39;).then(function(data) {
             </a>
           </h2>
 
-          <p>Load a single Image asset. Uses the base <a href="api/assets/#setImagePath">image path</a> to resolve the URL.</p>
-<p>Once loaded, the asset will be accessible on the the <a href="api/assets/#imageAssets">imageAssets</a> property.</p>
+          <p>Load a single Image asset. Uses the base <a href="api/assets#setImagePath">image path</a> to resolve the URL.</p>
+<p>Once loaded, the asset will be accessible on the the <a href="api/assets#imageAssets">imageAssets</a> property.</p>
 <div class="tablist">
   <ul role="tablist">
     <li role="presentation" data-tab="global">

--- a/docs/api/keyboard.html
+++ b/docs/api/keyboard.html
@@ -174,7 +174,7 @@ function update() {
             </a>
           </h2>
 
-          <p>Below is a list of keys that are provided by default. If you need to extend this list, you can use the <a href="api/keyboard/#keyMap">keyMap</a> property.</p>
+          <p>Below is a list of keys that are provided by default. If you need to extend this list, you can use the <a href="api/keyboard#keyMap">keyMap</a> property.</p>
 <ul>
 <li>a-z</li>
 <li>0-9</li>
@@ -268,7 +268,7 @@ bindKeys([&#39;enter&#39;, &#39;space&#39;], function(e) {
             </a>
           </h2>
 
-          <p>A map of keycodes to key names. Add to this object to expand the list of <a href="api/keyboard/#available-keys">available keys</a>.</p>
+          <p>A map of keycodes to key names. Add to this object to expand the list of <a href="api/keyboard#available-keys">available keys</a>.</p>
 <div class="tablist">
   <ul role="tablist">
     <li role="presentation" data-tab="global">

--- a/docs/api/pool.html
+++ b/docs/api/pool.html
@@ -287,7 +287,7 @@ let loop = GameLoop({
             </a>
           </h2>
 
-          <p>Clear the object pool. Removes all objects from the pool and resets its <a href="api/pool/#size">size</a> to 1.</p>
+          <p>Clear the object pool. Removes all objects from the pool and resets its <a href="api/pool#size">size</a> to 1.</p>
           
         </section>
         <section>

--- a/docs/api/sprite.html
+++ b/docs/api/sprite.html
@@ -380,22 +380,22 @@
           </h2>
 
           <p>In its most basic form, a sprite is a rectangle with a fill color. To create a rectangle sprite, pass the arguments <code>width</code>, <code>height</code>, and <code>color</code>. A rectangle sprite is great for initial prototyping and particles.</p>
-<canvas id="game-canvas-231"></canvas>
+<canvas id="game-canvas-0"></canvas>
 
 <div class="tablist">
   <ul role="tablist">
     <li role="presentation" data-tab="global">
-      <button role="tab" id="game-canvas-231-global-tab">Global Object</button>
+      <button role="tab" id="game-canvas-0-global-tab">Global Object</button>
     </li>
     <li role="presentation" data-tab="es">
-      <button role="tab" id="game-canvas-231-es-tab">ES Module Import</button>
+      <button role="tab" id="game-canvas-0-es-tab">ES Module Import</button>
     </li>
     <li role="presentation" data-tab="bundle">
-      <button role="tab" id="game-canvas-231-bundle-tab">Module Bundler</button>
+      <button role="tab" id="game-canvas-0-bundle-tab">Module Bundler</button>
     </li>
     <li role="presentation"></li>
   </ul>
-  <section role="tabpanel" aria-labelledby=game-canvas-231-global-tab data-tabpanel="global">
+  <section role="tabpanel" aria-labelledby=game-canvas-0-global-tab data-tabpanel="global">
     <pre><code class="lang-js">let { Sprite } &#x3D; kontra
 
 let sprite &#x3D; Sprite({
@@ -411,7 +411,7 @@ let sprite &#x3D; Sprite({
 
 sprite.render();</code></pre>
   </section>
-  <section role="tabpanel" aria-labelledby=game-canvas-231-es-tab data-tabpanel="es">
+  <section role="tabpanel" aria-labelledby=game-canvas-0-es-tab data-tabpanel="es">
     <pre><code class="lang-js">import { Sprite } from &#x27;path/to/kontra.mjs&#x27;
 
 let sprite &#x3D; Sprite({
@@ -427,7 +427,7 @@ let sprite &#x3D; Sprite({
 
 sprite.render();</code></pre>
   </section>
-  <section role="tabpanel" aria-labelledby=game-canvas-231-bundle-tab data-tabpanel="bundle">
+  <section role="tabpanel" aria-labelledby=game-canvas-0-bundle-tab data-tabpanel="bundle">
     <pre><code class="lang-js">import { Sprite } from &#x27;kontra&#x27;;
 
 let sprite &#x3D; Sprite({
@@ -446,8 +446,8 @@ sprite.render();</code></pre>
 </div>
 
 <script>(function() {
-  kontra.init("game-canvas-231");
-  var canvas = document.querySelector("#game-canvas-231");
+  kontra.init("game-canvas-0");
+  var canvas = document.querySelector("#game-canvas-0");
   canvas.width = 600;
   canvas.height = 200;
   var context = canvas.getContext("2d");
@@ -479,22 +479,22 @@ sprite.render();
           </h2>
 
           <p>A sprite can use an image instead of drawing a rectangle. To create an image sprite, pass the <code>image</code> argument. The size of the sprite will automatically be set as the width and height of the image.</p>
-<canvas id="game-canvas-232"></canvas>
+<canvas id="game-canvas-1"></canvas>
 
 <div class="tablist">
   <ul role="tablist">
     <li role="presentation" data-tab="global">
-      <button role="tab" id="game-canvas-232-global-tab">Global Object</button>
+      <button role="tab" id="game-canvas-1-global-tab">Global Object</button>
     </li>
     <li role="presentation" data-tab="es">
-      <button role="tab" id="game-canvas-232-es-tab">ES Module Import</button>
+      <button role="tab" id="game-canvas-1-es-tab">ES Module Import</button>
     </li>
     <li role="presentation" data-tab="bundle">
-      <button role="tab" id="game-canvas-232-bundle-tab">Module Bundler</button>
+      <button role="tab" id="game-canvas-1-bundle-tab">Module Bundler</button>
     </li>
     <li role="presentation"></li>
   </ul>
-  <section role="tabpanel" aria-labelledby=game-canvas-232-global-tab data-tabpanel="global">
+  <section role="tabpanel" aria-labelledby=game-canvas-1-global-tab data-tabpanel="global">
     <pre><code class="lang-js">let { Sprite } &#x3D; kontra
 
 let image &#x3D; new Image();
@@ -512,7 +512,7 @@ image.onload &#x3D; function() {
   sprite.render();
 };</code></pre>
   </section>
-  <section role="tabpanel" aria-labelledby=game-canvas-232-es-tab data-tabpanel="es">
+  <section role="tabpanel" aria-labelledby=game-canvas-1-es-tab data-tabpanel="es">
     <pre><code class="lang-js">import { Sprite } from &#x27;path/to/kontra.mjs&#x27;
 
 let image &#x3D; new Image();
@@ -530,7 +530,7 @@ image.onload &#x3D; function() {
   sprite.render();
 };</code></pre>
   </section>
-  <section role="tabpanel" aria-labelledby=game-canvas-232-bundle-tab data-tabpanel="bundle">
+  <section role="tabpanel" aria-labelledby=game-canvas-1-bundle-tab data-tabpanel="bundle">
     <pre><code class="lang-js">import { Sprite } from &#x27;kontra&#x27;;
 
 let image &#x3D; new Image();
@@ -551,8 +551,8 @@ image.onload &#x3D; function() {
 </div>
 
 <script>(function() {
-  kontra.init("game-canvas-232");
-  var canvas = document.querySelector("#game-canvas-232");
+  kontra.init("game-canvas-1");
+  var canvas = document.querySelector("#game-canvas-1");
   canvas.width = 600;
   canvas.height = 200;
   var context = canvas.getContext("2d");
@@ -587,22 +587,22 @@ image.onload = function() {
 
           <p>A sprite can use a spritesheet animation as well. To create an animation sprite, pass the <code>animations</code> argument. The size of the sprite will automatically be set as the width and height of a frame of the spritesheet.</p>
 <p>A sprite can have multiple named animations. The easiest way to create animations is to use <a href="api/spriteSheet">SpriteSheet</a>. All animations will automatically be <a href="animation#clone">cloned</a> so no two sprites update the same animation.</p>
-<canvas id="game-canvas-233"></canvas>
+<canvas id="game-canvas-2"></canvas>
 
 <div class="tablist">
   <ul role="tablist">
     <li role="presentation" data-tab="global">
-      <button role="tab" id="game-canvas-233-global-tab">Global Object</button>
+      <button role="tab" id="game-canvas-2-global-tab">Global Object</button>
     </li>
     <li role="presentation" data-tab="es">
-      <button role="tab" id="game-canvas-233-es-tab">ES Module Import</button>
+      <button role="tab" id="game-canvas-2-es-tab">ES Module Import</button>
     </li>
     <li role="presentation" data-tab="bundle">
-      <button role="tab" id="game-canvas-233-bundle-tab">Module Bundler</button>
+      <button role="tab" id="game-canvas-2-bundle-tab">Module Bundler</button>
     </li>
     <li role="presentation"></li>
   </ul>
-  <section role="tabpanel" aria-labelledby=game-canvas-233-global-tab data-tabpanel="global">
+  <section role="tabpanel" aria-labelledby=game-canvas-2-global-tab data-tabpanel="global">
     <pre><code class="lang-js">let { Sprite, SpriteSheet, GameLoop } &#x3D; kontra
 
 let image &#x3D; new Image();
@@ -645,7 +645,7 @@ image.onload &#x3D; function() {
   loop.start();
 };</code></pre>
   </section>
-  <section role="tabpanel" aria-labelledby=game-canvas-233-es-tab data-tabpanel="es">
+  <section role="tabpanel" aria-labelledby=game-canvas-2-es-tab data-tabpanel="es">
     <pre><code class="lang-js">import { Sprite, SpriteSheet, GameLoop } from &#x27;path/to/kontra.mjs&#x27;
 
 let image &#x3D; new Image();
@@ -688,7 +688,7 @@ image.onload &#x3D; function() {
   loop.start();
 };</code></pre>
   </section>
-  <section role="tabpanel" aria-labelledby=game-canvas-233-bundle-tab data-tabpanel="bundle">
+  <section role="tabpanel" aria-labelledby=game-canvas-2-bundle-tab data-tabpanel="bundle">
     <pre><code class="lang-js">import { Sprite, SpriteSheet, GameLoop } from &#x27;kontra&#x27;;
 
 let image &#x3D; new Image();
@@ -734,8 +734,8 @@ image.onload &#x3D; function() {
 </div>
 
 <script>(function() {
-  kontra.init("game-canvas-233");
-  var canvas = document.querySelector("#game-canvas-233");
+  kontra.init("game-canvas-2");
+  var canvas = document.querySelector("#game-canvas-2");
   canvas.width = 600;
   canvas.height = 200;
   var context = canvas.getContext("2d");
@@ -800,22 +800,22 @@ image.onload = function() {
           </h2>
 
           <p>If you need to draw a different shape, such as a circle, you can pass in custom properties and a render function to handle drawing the sprite.</p>
-<canvas id="game-canvas-234"></canvas>
+<canvas id="game-canvas-3"></canvas>
 
 <div class="tablist">
   <ul role="tablist">
     <li role="presentation" data-tab="global">
-      <button role="tab" id="game-canvas-234-global-tab">Global Object</button>
+      <button role="tab" id="game-canvas-3-global-tab">Global Object</button>
     </li>
     <li role="presentation" data-tab="es">
-      <button role="tab" id="game-canvas-234-es-tab">ES Module Import</button>
+      <button role="tab" id="game-canvas-3-es-tab">ES Module Import</button>
     </li>
     <li role="presentation" data-tab="bundle">
-      <button role="tab" id="game-canvas-234-bundle-tab">Module Bundler</button>
+      <button role="tab" id="game-canvas-3-bundle-tab">Module Bundler</button>
     </li>
     <li role="presentation"></li>
   </ul>
-  <section role="tabpanel" aria-labelledby=game-canvas-234-global-tab data-tabpanel="global">
+  <section role="tabpanel" aria-labelledby=game-canvas-3-global-tab data-tabpanel="global">
     <pre><code class="lang-js">let { Sprite } &#x3D; kontra
 
 let sprite &#x3D; Sprite({
@@ -838,7 +838,7 @@ let sprite &#x3D; Sprite({
 
 sprite.render();</code></pre>
   </section>
-  <section role="tabpanel" aria-labelledby=game-canvas-234-es-tab data-tabpanel="es">
+  <section role="tabpanel" aria-labelledby=game-canvas-3-es-tab data-tabpanel="es">
     <pre><code class="lang-js">import { Sprite } from &#x27;path/to/kontra.mjs&#x27;
 
 let sprite &#x3D; Sprite({
@@ -861,7 +861,7 @@ let sprite &#x3D; Sprite({
 
 sprite.render();</code></pre>
   </section>
-  <section role="tabpanel" aria-labelledby=game-canvas-234-bundle-tab data-tabpanel="bundle">
+  <section role="tabpanel" aria-labelledby=game-canvas-3-bundle-tab data-tabpanel="bundle">
     <pre><code class="lang-js">import { Sprite } from &#x27;kontra&#x27;;
 
 let sprite &#x3D; Sprite({
@@ -887,8 +887,8 @@ sprite.render();</code></pre>
 </div>
 
 <script>(function() {
-  kontra.init("game-canvas-234");
-  var canvas = document.querySelector("#game-canvas-234");
+  kontra.init("game-canvas-3");
+  var canvas = document.querySelector("#game-canvas-3");
   canvas.width = 600;
   canvas.height = 200;
   var context = canvas.getContext("2d");
@@ -978,8 +978,8 @@ class CustomSprite extends Sprite.class {
             </a>
           </h2>
 
-          <p>Move the sprite by its acceleration and velocity. If the sprite is an <a href="api/sprite/#animation-sprite">animation sprite</a>, it also advances the animation every frame.</p>
-<p>If you override the sprites <a href="api/sprite/#update">update()</a> function with your own update function, you can call this function to move the sprite normally.</p>
+          <p>Move the sprite by its acceleration and velocity. If the sprite is an <a href="api/sprite#animation-sprite">animation sprite</a>, it also advances the animation every frame.</p>
+<p>If you override the sprites <a href="api/sprite#update">update()</a> function with your own update function, you can call this function to move the sprite normally.</p>
 <div class="tablist">
   <ul role="tablist">
     <li role="presentation" data-tab="global">
@@ -1086,22 +1086,22 @@ let sprite = Sprite({
           </h2>
 
           <p>The x and y origin of the sprite. {x:0, y:0} is the top left corner of the sprite, {x:1, y:1} is the bottom right corner.</p>
-<canvas id="game-canvas-235"></canvas>
+<canvas id="game-canvas-4"></canvas>
 
 <div class="tablist">
   <ul role="tablist">
     <li role="presentation" data-tab="global">
-      <button role="tab" id="game-canvas-235-global-tab">Global Object</button>
+      <button role="tab" id="game-canvas-4-global-tab">Global Object</button>
     </li>
     <li role="presentation" data-tab="es">
-      <button role="tab" id="game-canvas-235-es-tab">ES Module Import</button>
+      <button role="tab" id="game-canvas-4-es-tab">ES Module Import</button>
     </li>
     <li role="presentation" data-tab="bundle">
-      <button role="tab" id="game-canvas-235-bundle-tab">Module Bundler</button>
+      <button role="tab" id="game-canvas-4-bundle-tab">Module Bundler</button>
     </li>
     <li role="presentation"></li>
   </ul>
-  <section role="tabpanel" aria-labelledby=game-canvas-235-global-tab data-tabpanel="global">
+  <section role="tabpanel" aria-labelledby=game-canvas-4-global-tab data-tabpanel="global">
     <pre><code class="lang-js">let { Sprite } &#x3D; kontra
 
 let sprite &#x3D; Sprite({
@@ -1130,7 +1130,7 @@ sprite.anchor &#x3D; {x: 1, y: 1};
 sprite.x &#x3D; 450;
 sprite.render();</code></pre>
   </section>
-  <section role="tabpanel" aria-labelledby=game-canvas-235-es-tab data-tabpanel="es">
+  <section role="tabpanel" aria-labelledby=game-canvas-4-es-tab data-tabpanel="es">
     <pre><code class="lang-js">import { Sprite } from &#x27;path/to/kontra.mjs&#x27;
 
 let sprite &#x3D; Sprite({
@@ -1159,7 +1159,7 @@ sprite.anchor &#x3D; {x: 1, y: 1};
 sprite.x &#x3D; 450;
 sprite.render();</code></pre>
   </section>
-  <section role="tabpanel" aria-labelledby=game-canvas-235-bundle-tab data-tabpanel="bundle">
+  <section role="tabpanel" aria-labelledby=game-canvas-4-bundle-tab data-tabpanel="bundle">
     <pre><code class="lang-js">import { Sprite } from &#x27;kontra&#x27;;
 
 let sprite &#x3D; Sprite({
@@ -1191,8 +1191,8 @@ sprite.render();</code></pre>
 </div>
 
 <script>(function() {
-  kontra.init("game-canvas-235");
-  var canvas = document.querySelector("#game-canvas-235");
+  kontra.init("game-canvas-4");
+  var canvas = document.querySelector("#game-canvas-4");
   canvas.width = 600;
   canvas.height = 200;
   var context = canvas.getContext("2d");
@@ -1237,7 +1237,7 @@ sprite.render();
             </a>
           </h2>
 
-          <p>An object of <a href="api/animation">Animations</a> from a <a href="api/spriteSheet">SpriteSheet</a> to animate the sprite. Each animation is named so that it can can be used by name for the sprites <a href="api/sprite/#playAnimation">playAnimation()</a> function.</p>
+          <p>An object of <a href="api/animation">Animations</a> from a <a href="api/spriteSheet">SpriteSheet</a> to animate the sprite. Each animation is named so that it can can be used by name for the sprites <a href="api/sprite#playAnimation">playAnimation()</a> function.</p>
 <div class="tablist">
   <ul role="tablist">
     <li role="presentation" data-tab="global">
@@ -1328,7 +1328,7 @@ sprite.playAnimation(&#39;idle&#39;);</code></pre></section>
             </a>
           </h2>
 
-          <p>Check if the sprite collide with the object. Uses a simple <a href="https://developer.mozilla.org/en-US/docs/Games/Techniques/2D_collision_detection#Axis-Aligned_Bounding_Box">Axis-Aligned Bounding Box (AABB) collision check</a>. Takes into account the sprites <a href="api/sprite/#anchor">anchor</a>.</p>
+          <p>Check if the sprite collide with the object. Uses a simple <a href="https://developer.mozilla.org/en-US/docs/Games/Techniques/2D_collision_detection#Axis-Aligned_Bounding_Box">Axis-Aligned Bounding Box (AABB) collision check</a>. Takes into account the sprites <a href="api/sprite#anchor">anchor</a>.</p>
 <p><strong>NOTE:</strong> Does not take into account sprite rotation. If you need collision detection between rotated sprites you will need to implement your own <code>collidesWith()</code> function. I suggest looking at the Separate Axis Theorem.</p>
 <div class="tablist">
   <ul role="tablist">
@@ -1571,7 +1571,7 @@ sprite.collidesWith(sprite2);  //=&gt; true</code></pre></section>
             </a>
           </h2>
 
-          <p>Draw the sprite at its X and Y position. This function changes based on the type of the sprite. For a <a href="api/sprite/#rectangle-sprite">rectangle sprite</a>, it uses <code>context.fillRect()</code>, for an <a href="api/sprite/#image-sprite">image sprite</a> it uses <code>context.drawImage()</code>, and for an <a href="api/sprite/#animation-sprite">animation sprite</a> it uses the <a href="api/sprite/#currentAnimation">currentAnimation</a> <code>render()</code> function.</p>
+          <p>Draw the sprite at its X and Y position. This function changes based on the type of the sprite. For a <a href="api/sprite#rectangle-sprite">rectangle sprite</a>, it uses <code>context.fillRect()</code>, for an <a href="api/sprite#image-sprite">image sprite</a> it uses <code>context.drawImage()</code>, and for an <a href="api/sprite#animation-sprite">animation sprite</a> it uses the <a href="api/sprite#currentAnimation">currentAnimation</a> <code>render()</code> function.</p>
 <p>If you override the sprites <code>render()</code> function with your own render function, you can call this function to draw the sprite normally.</p>
 <div class="tablist">
   <ul role="tablist">
@@ -1682,7 +1682,7 @@ sprite.render();</code></pre></section>
             </a>
           </h2>
 
-          <p>The height of the sprite. If the sprite is a <a href="api/sprite/#rectangle-sprite">rectangle sprite</a>, it uses the passed in value. For an <a href="api/sprite/#image-sprite">image sprite</a> it is the height of the image. And for an <a href="api/sprite/#animation-sprite">animation sprite</a> it is the height of a single frame of the animation.</p>
+          <p>The height of the sprite. If the sprite is a <a href="api/sprite#rectangle-sprite">rectangle sprite</a>, it uses the passed in value. For an <a href="api/sprite#image-sprite">image sprite</a> it is the height of the image. And for an <a href="api/sprite#animation-sprite">animation sprite</a> it is the height of a single frame of the animation.</p>
 <p>Setting the value to a negative number will result in the sprite being flipped across the horizontal axis while the height will remain a positive value.</p>
           
         </section>
@@ -1728,7 +1728,7 @@ sprite.render();</code></pre></section>
           <p>Check if the sprite is alive. Primarily used by <a href="api/pool">Pool</a> to know when to recycle an object.</p>
           
           <h3><span class="visually-hidden">isAlive</span> Return value</h3>
-          <p><p><code>true</code> if the sprites <a href="api/sprite/#ttl">ttl</a> property is above <code>0</code>, <code>false</code> otherwise.</p>
+          <p><p><code>true</code> if the sprites <a href="api/sprite#ttl">ttl</a> property is above <code>0</code>, <code>false</code> otherwise.</p>
           </p>
         </section>
         <section>
@@ -1847,7 +1847,7 @@ sprite.playAnimation(&#39;idle&#39;);</code></pre></section>
             </a>
           </h2>
 
-          <p>Render the sprite. Calls the sprites <a href="api/sprite/#draw">draw()</a> function.</p>
+          <p>Render the sprite. Calls the sprites <a href="api/sprite#draw">draw()</a> function.</p>
           
         </section>
         <section>
@@ -1902,7 +1902,7 @@ sprite.playAnimation(&#39;idle&#39;);</code></pre></section>
             </a>
           </h2>
 
-          <p>Update the sprites position based on its velocity and acceleration. Calls the sprites <a href="api/sprite/#advance">advance()</a> function.</p>
+          <p>Update the sprites position based on its velocity and acceleration. Calls the sprites <a href="api/sprite#advance">advance()</a> function.</p>
           <h3 id="title-update"><span class="visually-hidden">update</span> Parameters</span></h3>
           <dl aria-labelledby="title-update">
             <dt>
@@ -1955,7 +1955,7 @@ sprite.playAnimation(&#39;idle&#39;);</code></pre></section>
             </a>
           </h2>
 
-          <p>The width of the sprite. If the sprite is a <a href="api/sprite/#rectangle-sprite">rectangle sprite</a>, it uses the passed in value. For an <a href="api/sprite/#image-sprite">image sprite</a> it is the width of the image. And for an <a href="api/sprite/#animation-sprite">animation sprite</a> it is the width of a single frame of the animation.</p>
+          <p>The width of the sprite. If the sprite is a <a href="api/sprite#rectangle-sprite">rectangle sprite</a>, it uses the passed in value. For an <a href="api/sprite#image-sprite">image sprite</a> it is the width of the image. And for an <a href="api/sprite#animation-sprite">animation sprite</a> it is the width of a single frame of the animation.</p>
 <p>Setting the value to a negative number will result in the sprite being flipped across the vertical axis while the width will remain a positive value.</p>
           
         </section>

--- a/docs/api/spriteSheet.html
+++ b/docs/api/spriteSheet.html
@@ -68,7 +68,7 @@
         <h1>SpriteSheet(&#8203;properties)
         </h1>
 
-        <p>A sprite sheet to animate a sequence of images. Used to create <a href="api/sprite/#animation-sprite">animation sprites</a>.</p>
+        <p>A sprite sheet to animate a sequence of images. Used to create <a href="api/sprite#animation-sprite">animation sprites</a>.</p>
 <figure>
   <a href="assets/imgs/character_walk_sheet.png">
     <img src="assets/imgs/character_walk_sheet.png" alt="11 frames of a walking pill-like alien wearing a space helmet.">
@@ -205,7 +205,7 @@ image.onload = function() {
             <code>properties.animations</code>
             <span class="optional">Optional</span>
           </dt>
-          <dd><p>Object. Animations to create from the sprite sheet using <a href="api/animation">Animation</a>. Passed directly into the sprite sheets <a href="api/spriteSheet/#createAnimations">createAnimations()</a> function.</p>
+          <dd><p>Object. Animations to create from the sprite sheet using <a href="api/animation">Animation</a>. Passed directly into the sprite sheets <a href="api/spriteSheet#createAnimations">createAnimations()</a> function.</p>
         </dd>
         </dl>
         
@@ -258,7 +258,7 @@ image.onload = function() {
             </a>
           </h2>
 
-          <p>An object of named <a href="api/animation">Animation</a> objects. Typically you pass this object into <a href="api/sprite">Sprite</a> to create an <a href="api/spriteSheet/#animation-sprite">animation sprites</a>.</p>
+          <p>An object of named <a href="api/animation">Animation</a> objects. Typically you pass this object into <a href="api/sprite">Sprite</a> to create an <a href="api/spriteSheet#animation-sprite">animation sprites</a>.</p>
           
         </section>
         <section>

--- a/docs/api/tileEngine.html
+++ b/docs/api/tileEngine.html
@@ -129,7 +129,7 @@
             <code>properties.tilesetN.image</code>
             
           </dt>
-          <dd><p>String or HTMLImageElement. Relative path to the HTMLImageElement or an HTMLImageElement. If passing a relative path, the image file must have been <a href="api/assets/#load">loaded</a> first.</p>
+          <dd><p>String or HTMLImageElement. Relative path to the HTMLImageElement or an HTMLImageElement. If passing a relative path, the image file must have been <a href="api/assets#load">loaded</a> first.</p>
         </dd>
           <dt>
             <code>properties.tilesetN.margin</code>
@@ -153,7 +153,7 @@
             <code>properties.tilesetN.source</code>
             <span class="optional">Optional</span>
           </dt>
-          <dd><p>String. Relative path to the source JSON file. The source JSON file must have been <a href="api/assets/#load">loaded</a> first.</p>
+          <dd><p>String. Relative path to the source JSON file. The source JSON file must have been <a href="api/assets#load">loaded</a> first.</p>
         </dd>
           <dt>
             <code>properties.tilesetN.columns</code>
@@ -334,22 +334,22 @@
 <p>You&#39;ll then need to add at least one tileset with an image as well as firstgid, or first tile index of the tileset. The first tileset will always have a firstgid of 1 as 0 represents an empty tile.</p>
 <p>Lastly, you&#39;ll need to add at least one named layer with data. A layer tells the tile engine which tiles from the tileset image to use at what position on the map.</p>
 <p>Once all tileset images and all layers have been added, you can render the tile engine by calling its <a href="api/tileEngine#render">render()</a> function.</p>
-<canvas id="game-canvas-236"></canvas>
+<canvas id="game-canvas-5"></canvas>
 
 <div class="tablist">
   <ul role="tablist">
     <li role="presentation" data-tab="global">
-      <button role="tab" id="game-canvas-236-global-tab">Global Object</button>
+      <button role="tab" id="game-canvas-5-global-tab">Global Object</button>
     </li>
     <li role="presentation" data-tab="es">
-      <button role="tab" id="game-canvas-236-es-tab">ES Module Import</button>
+      <button role="tab" id="game-canvas-5-es-tab">ES Module Import</button>
     </li>
     <li role="presentation" data-tab="bundle">
-      <button role="tab" id="game-canvas-236-bundle-tab">Module Bundler</button>
+      <button role="tab" id="game-canvas-5-bundle-tab">Module Bundler</button>
     </li>
     <li role="presentation"></li>
   </ul>
-  <section role="tabpanel" aria-labelledby=game-canvas-236-global-tab data-tabpanel="global">
+  <section role="tabpanel" aria-labelledby=game-canvas-5-global-tab data-tabpanel="global">
     <pre><code class="lang-js">let { TileEngine } &#x3D; kontra
 
 let img &#x3D; new Image();
@@ -388,7 +388,7 @@ img.onload &#x3D; function() {
   tileEngine.render();
 }</code></pre>
   </section>
-  <section role="tabpanel" aria-labelledby=game-canvas-236-es-tab data-tabpanel="es">
+  <section role="tabpanel" aria-labelledby=game-canvas-5-es-tab data-tabpanel="es">
     <pre><code class="lang-js">import { TileEngine } from &#x27;path/to/kontra.mjs&#x27;
 
 let img &#x3D; new Image();
@@ -427,7 +427,7 @@ img.onload &#x3D; function() {
   tileEngine.render();
 }</code></pre>
   </section>
-  <section role="tabpanel" aria-labelledby=game-canvas-236-bundle-tab data-tabpanel="bundle">
+  <section role="tabpanel" aria-labelledby=game-canvas-5-bundle-tab data-tabpanel="bundle">
     <pre><code class="lang-js">import { TileEngine } from &#x27;kontra&#x27;;
 
 let img &#x3D; new Image();
@@ -469,8 +469,8 @@ img.onload &#x3D; function() {
 </div>
 
 <script>(function() {
-  kontra.init("game-canvas-236");
-  var canvas = document.querySelector("#game-canvas-236");
+  kontra.init("game-canvas-5");
+  var canvas = document.querySelector("#game-canvas-5");
   canvas.width = 576;
   canvas.height = 576;
   var context = canvas.getContext("2d");
@@ -526,22 +526,22 @@ img.onload = function() {
 
           <p>Adding all the tileset images and layers to a tile engine can be tedious, especially if you have multiple layers. If you want a simpler way to create a tile engine, Kontra has been written to work directly with the JSON output of the <a href="http://www.mapeditor.org/">Tiled Map Editor</a>.</p>
 <p>The one requirement is that you must preload all of the tileset images and tileset sources using the appropriate <a href="./assets">asset loader functions</a> before you create the tile engine.</p>
-<canvas id="game-canvas-237"></canvas>
+<canvas id="game-canvas-6"></canvas>
 
 <div class="tablist">
   <ul role="tablist">
     <li role="presentation" data-tab="global">
-      <button role="tab" id="game-canvas-237-global-tab">Global Object</button>
+      <button role="tab" id="game-canvas-6-global-tab">Global Object</button>
     </li>
     <li role="presentation" data-tab="es">
-      <button role="tab" id="game-canvas-237-es-tab">ES Module Import</button>
+      <button role="tab" id="game-canvas-6-es-tab">ES Module Import</button>
     </li>
     <li role="presentation" data-tab="bundle">
-      <button role="tab" id="game-canvas-237-bundle-tab">Module Bundler</button>
+      <button role="tab" id="game-canvas-6-bundle-tab">Module Bundler</button>
     </li>
     <li role="presentation"></li>
   </ul>
-  <section role="tabpanel" aria-labelledby=game-canvas-237-global-tab data-tabpanel="global">
+  <section role="tabpanel" aria-labelledby=game-canvas-6-global-tab data-tabpanel="global">
     <pre><code class="lang-js">let { load, TileEngine, dataAssets } &#x3D; kontra
 
 load(&#x27;assets/imgs/mapPack_tilesheet.png&#x27;, &#x27;assets/data/tile_engine_basic.json&#x27;)
@@ -550,7 +550,7 @@ load(&#x27;assets/imgs/mapPack_tilesheet.png&#x27;, &#x27;assets/data/tile_engin
     tileEngine.render();
   });</code></pre>
   </section>
-  <section role="tabpanel" aria-labelledby=game-canvas-237-es-tab data-tabpanel="es">
+  <section role="tabpanel" aria-labelledby=game-canvas-6-es-tab data-tabpanel="es">
     <pre><code class="lang-js">import { load, TileEngine, dataAssets } from &#x27;path/to/kontra.mjs&#x27;
 
 load(&#x27;assets/imgs/mapPack_tilesheet.png&#x27;, &#x27;assets/data/tile_engine_basic.json&#x27;)
@@ -559,7 +559,7 @@ load(&#x27;assets/imgs/mapPack_tilesheet.png&#x27;, &#x27;assets/data/tile_engin
     tileEngine.render();
   });</code></pre>
   </section>
-  <section role="tabpanel" aria-labelledby=game-canvas-237-bundle-tab data-tabpanel="bundle">
+  <section role="tabpanel" aria-labelledby=game-canvas-6-bundle-tab data-tabpanel="bundle">
     <pre><code class="lang-js">import { load, TileEngine, dataAssets } from &#x27;kontra&#x27;;
 
 load(&#x27;assets/imgs/mapPack_tilesheet.png&#x27;, &#x27;assets/data/tile_engine_basic.json&#x27;)
@@ -571,8 +571,8 @@ load(&#x27;assets/imgs/mapPack_tilesheet.png&#x27;, &#x27;assets/data/tile_engin
 </div>
 
 <script>(function() {
-  kontra.init("game-canvas-237");
-  var canvas = document.querySelector("#game-canvas-237");
+  kontra.init("game-canvas-6");
+  var canvas = document.querySelector("#game-canvas-6");
   canvas.width = 576;
   canvas.height = 576;
   var context = canvas.getContext("2d");
@@ -598,22 +598,22 @@ load('assets/imgs/mapPack_tilesheet.png', 'assets/data/tile_engine_basic.json')
 
           <p>If your tilemap is larger than the canvas size, you can move the tilemap camera to change how the tilemap is drawn. Use the tile engines <a href="api/tileEngine#sx">sx</a> and <a href="api/tileEngine#sy">sy</a> properties to move the camera. Just like drawing an image, the cameras coordinates are the top left corner.</p>
 <p>The <code>sx</code> and <code>sy</code> coordinates will never draw the tile map below 0 or beyond the last row or column of the tile map.</p>
-<canvas id="game-canvas-238"></canvas>
+<canvas id="game-canvas-7"></canvas>
 
 <div class="tablist">
   <ul role="tablist">
     <li role="presentation" data-tab="global">
-      <button role="tab" id="game-canvas-238-global-tab">Global Object</button>
+      <button role="tab" id="game-canvas-7-global-tab">Global Object</button>
     </li>
     <li role="presentation" data-tab="es">
-      <button role="tab" id="game-canvas-238-es-tab">ES Module Import</button>
+      <button role="tab" id="game-canvas-7-es-tab">ES Module Import</button>
     </li>
     <li role="presentation" data-tab="bundle">
-      <button role="tab" id="game-canvas-238-bundle-tab">Module Bundler</button>
+      <button role="tab" id="game-canvas-7-bundle-tab">Module Bundler</button>
     </li>
     <li role="presentation"></li>
   </ul>
-  <section role="tabpanel" aria-labelledby=game-canvas-238-global-tab data-tabpanel="global">
+  <section role="tabpanel" aria-labelledby=game-canvas-7-global-tab data-tabpanel="global">
     <pre><code class="lang-js">let { load, TileEngine, dataAssets, GameLoop } &#x3D; kontra
 
 load(&#x27;assets/imgs/mapPack_tilesheet.png&#x27;, &#x27;assets/data/tile_engine_camera.json&#x27;)
@@ -637,7 +637,7 @@ load(&#x27;assets/imgs/mapPack_tilesheet.png&#x27;, &#x27;assets/data/tile_engin
     loop.start();
   });</code></pre>
   </section>
-  <section role="tabpanel" aria-labelledby=game-canvas-238-es-tab data-tabpanel="es">
+  <section role="tabpanel" aria-labelledby=game-canvas-7-es-tab data-tabpanel="es">
     <pre><code class="lang-js">import { load, TileEngine, dataAssets, GameLoop } from &#x27;path/to/kontra.mjs&#x27;
 
 load(&#x27;assets/imgs/mapPack_tilesheet.png&#x27;, &#x27;assets/data/tile_engine_camera.json&#x27;)
@@ -661,7 +661,7 @@ load(&#x27;assets/imgs/mapPack_tilesheet.png&#x27;, &#x27;assets/data/tile_engin
     loop.start();
   });</code></pre>
   </section>
-  <section role="tabpanel" aria-labelledby=game-canvas-238-bundle-tab data-tabpanel="bundle">
+  <section role="tabpanel" aria-labelledby=game-canvas-7-bundle-tab data-tabpanel="bundle">
     <pre><code class="lang-js">import { load, TileEngine, dataAssets, GameLoop } from &#x27;kontra&#x27;;
 
 load(&#x27;assets/imgs/mapPack_tilesheet.png&#x27;, &#x27;assets/data/tile_engine_camera.json&#x27;)
@@ -688,8 +688,8 @@ load(&#x27;assets/imgs/mapPack_tilesheet.png&#x27;, &#x27;assets/data/tile_engin
 </div>
 
 <script>(function() {
-  kontra.init("game-canvas-238");
-  var canvas = document.querySelector("#game-canvas-238");
+  kontra.init("game-canvas-7");
+  var canvas = document.querySelector("#game-canvas-7");
   canvas.width = 576;
   canvas.height = 576;
   var context = canvas.getContext("2d");
@@ -729,22 +729,22 @@ load('assets/imgs/mapPack_tilesheet.png', 'assets/data/tile_engine_camera.json')
           </h2>
 
           <p>Managing the correct x and y position of sprites on a large tile map can be tricky. You can add objects to the tile map which will sync the camera position with the sprite. <a href="api/sprite">Sprite</a> will automatically draw the sprite for you at the correct position on the tile map even while the camera moves.</p>
-<canvas id="game-canvas-240"></canvas>
+<canvas id="game-canvas-9"></canvas>
 
 <div class="tablist">
   <ul role="tablist">
     <li role="presentation" data-tab="global">
-      <button role="tab" id="game-canvas-240-global-tab">Global Object</button>
+      <button role="tab" id="game-canvas-9-global-tab">Global Object</button>
     </li>
     <li role="presentation" data-tab="es">
-      <button role="tab" id="game-canvas-240-es-tab">ES Module Import</button>
+      <button role="tab" id="game-canvas-9-es-tab">ES Module Import</button>
     </li>
     <li role="presentation" data-tab="bundle">
-      <button role="tab" id="game-canvas-240-bundle-tab">Module Bundler</button>
+      <button role="tab" id="game-canvas-9-bundle-tab">Module Bundler</button>
     </li>
     <li role="presentation"></li>
   </ul>
-  <section role="tabpanel" aria-labelledby=game-canvas-240-global-tab data-tabpanel="global">
+  <section role="tabpanel" aria-labelledby=game-canvas-9-global-tab data-tabpanel="global">
     <pre><code class="lang-js">let { load, TileEngine, dataAssets, imageAssets, SpriteSheet, Sprite, GameLoop } &#x3D; kontra
 
 load(&#x27;assets/imgs/mapPack_tilesheet.png&#x27;, &#x27;assets/data/tile_engine_add.json&#x27;)
@@ -793,7 +793,7 @@ load(&#x27;assets/imgs/mapPack_tilesheet.png&#x27;, &#x27;assets/data/tile_engin
     loop.start();
   });</code></pre>
   </section>
-  <section role="tabpanel" aria-labelledby=game-canvas-240-es-tab data-tabpanel="es">
+  <section role="tabpanel" aria-labelledby=game-canvas-9-es-tab data-tabpanel="es">
     <pre><code class="lang-js">import { load, TileEngine, dataAssets, imageAssets, SpriteSheet, Sprite, GameLoop } from &#x27;path/to/kontra.mjs&#x27;
 
 load(&#x27;assets/imgs/mapPack_tilesheet.png&#x27;, &#x27;assets/data/tile_engine_add.json&#x27;)
@@ -842,7 +842,7 @@ load(&#x27;assets/imgs/mapPack_tilesheet.png&#x27;, &#x27;assets/data/tile_engin
     loop.start();
   });</code></pre>
   </section>
-  <section role="tabpanel" aria-labelledby=game-canvas-240-bundle-tab data-tabpanel="bundle">
+  <section role="tabpanel" aria-labelledby=game-canvas-9-bundle-tab data-tabpanel="bundle">
     <pre><code class="lang-js">import { load, TileEngine, dataAssets, imageAssets, SpriteSheet, Sprite, GameLoop } from &#x27;kontra&#x27;;
 
 load(&#x27;assets/imgs/mapPack_tilesheet.png&#x27;, &#x27;assets/data/tile_engine_add.json&#x27;)
@@ -894,8 +894,8 @@ load(&#x27;assets/imgs/mapPack_tilesheet.png&#x27;, &#x27;assets/data/tile_engin
 </div>
 
 <script>(function() {
-  kontra.init("game-canvas-240");
-  var canvas = document.querySelector("#game-canvas-240");
+  kontra.init("game-canvas-9");
+  var canvas = document.querySelector("#game-canvas-9");
   canvas.width = 576;
   canvas.height = 576;
   var context = canvas.getContext("2d");

--- a/docs/getting-started.html
+++ b/docs/getting-started.html
@@ -115,22 +115,22 @@ let { canvas, context } = init();</code></pre></section>
 </div>
 <h2 id="create">Create</h2>
 <p>After the game is initialize, you can create a simple <a href="api/sprite.html">Sprite</a> and <a href="api/gameLoop.html">Game Loop</a> in just a few lines of code</p>
-<canvas id="game-canvas-241"></canvas>
+<canvas id="game-canvas-10"></canvas>
 
 <div class="tablist">
   <ul role="tablist">
     <li role="presentation" data-tab="global">
-      <button role="tab" id="game-canvas-241-global-tab">Global Object</button>
+      <button role="tab" id="game-canvas-10-global-tab">Global Object</button>
     </li>
     <li role="presentation" data-tab="es">
-      <button role="tab" id="game-canvas-241-es-tab">ES Module Import</button>
+      <button role="tab" id="game-canvas-10-es-tab">ES Module Import</button>
     </li>
     <li role="presentation" data-tab="bundle">
-      <button role="tab" id="game-canvas-241-bundle-tab">Module Bundler</button>
+      <button role="tab" id="game-canvas-10-bundle-tab">Module Bundler</button>
     </li>
     <li role="presentation"></li>
   </ul>
-  <section role="tabpanel" aria-labelledby=game-canvas-241-global-tab data-tabpanel="global">
+  <section role="tabpanel" aria-labelledby=game-canvas-10-global-tab data-tabpanel="global">
     <pre><code class="lang-js">let { init, Sprite, GameLoop } &#x3D; kontra
 
 let { canvas } &#x3D; init();
@@ -161,7 +161,7 @@ let loop &#x3D; GameLoop({  // create the main game loop
 
 loop.start();    // start the game</code></pre>
   </section>
-  <section role="tabpanel" aria-labelledby=game-canvas-241-es-tab data-tabpanel="es">
+  <section role="tabpanel" aria-labelledby=game-canvas-10-es-tab data-tabpanel="es">
     <pre><code class="lang-js">import { init, Sprite, GameLoop } from &#x27;path/to/kontra.mjs&#x27;
 
 let { canvas } &#x3D; init();
@@ -192,7 +192,7 @@ let loop &#x3D; GameLoop({  // create the main game loop
 
 loop.start();    // start the game</code></pre>
   </section>
-  <section role="tabpanel" aria-labelledby=game-canvas-241-bundle-tab data-tabpanel="bundle">
+  <section role="tabpanel" aria-labelledby=game-canvas-10-bundle-tab data-tabpanel="bundle">
     <pre><code class="lang-js">import { init, Sprite, GameLoop } from &#x27;kontra&#x27;;
 
 let { canvas } &#x3D; init();
@@ -226,8 +226,8 @@ loop.start();    // start the game</code></pre>
 </div>
 
 <script>(function() {
-  kontra.init("game-canvas-241");
-  var canvas = document.querySelector("#game-canvas-241");
+  kontra.init("game-canvas-10");
+  var canvas = document.querySelector("#game-canvas-10");
   canvas.width = 600;
   canvas.height = 200;
   var context = canvas.getContext("2d");

--- a/src/animation.js
+++ b/src/animation.js
@@ -69,21 +69,21 @@ class Animation {
     let { width, height, margin = 0 } = spriteSheet.frame;
 
     /**
-     * The width of an individual frame. Taken from the property of the same name in the [spriteSheet](api/animation/#spriteSheet).
+     * The width of an individual frame. Taken from the property of the same name in the [spriteSheet](api/animation#spriteSheet).
      * @memberof Animation
      * @property {Number} width
      */
     this.width = width;
 
     /**
-     * The height of an individual frame. Taken from the property of the same name in the [spriteSheet](api/animation/#spriteSheet).
+     * The height of an individual frame. Taken from the property of the same name in the [spriteSheet](api/animation#spriteSheet).
      * @memberof Animation
      * @property {Number} height
      */
     this.height = height;
 
     /**
-     * The space between each frame. Taken from the property of the same name in the [spriteSheet](api/animation/#spriteSheet).
+     * The space between each frame. Taken from the property of the same name in the [spriteSheet](api/animation#spriteSheet).
      * @memberof Animation
      * @property {Number} margin
      */

--- a/src/assets.js
+++ b/src/assets.js
@@ -107,7 +107,7 @@ function getCanPlay(audio) {
 }
 
 /**
- * Object of all loaded image assets by both file name and path. If the base [image path](api/assets/#setImagePath) was set before the image was loaded, the file name and path will not include the base image path.
+ * Object of all loaded image assets by both file name and path. If the base [image path](api/assets#setImagePath) was set before the image was loaded, the file name and path will not include the base image path.
  *
  * ```js
  * import { load, setImagePath, imageAssets } from 'kontra';
@@ -130,7 +130,7 @@ function getCanPlay(audio) {
 export let imageAssets = {};
 
 /**
- * Object of all loaded audio assets by both file name and path. If the base [audio path](api/assets/#setAudioPath) was set before the audio was loaded, the file name and path will not include the base audio path.
+ * Object of all loaded audio assets by both file name and path. If the base [audio path](api/assets#setAudioPath) was set before the audio was loaded, the file name and path will not include the base audio path.
  *
  * ```js
  * import { load, setAudioPath, audioAssets } from 'kontra';
@@ -153,7 +153,7 @@ export let imageAssets = {};
 export let audioAssets = {};
 
 /**
- * Object of all loaded data assets by both file name and path. If the base [data path](api/assets/#setDataPath) was set before the data was loaded, the file name and path will not include the base data path.
+ * Object of all loaded data assets by both file name and path. If the base [data path](api/assets#setDataPath) was set before the data was loaded, the file name and path will not include the base data path.
  *
  * ```js
  * import { load, setDataPath, dataAssets } from 'kontra';
@@ -243,9 +243,9 @@ export function setDataPath(path) {
 }
 
 /**
- * Load a single Image asset. Uses the base [image path](api/assets/#setImagePath) to resolve the URL.
+ * Load a single Image asset. Uses the base [image path](api/assets#setImagePath) to resolve the URL.
  *
- * Once loaded, the asset will be accessible on the the [imageAssets](api/assets/#imageAssets) property.
+ * Once loaded, the asset will be accessible on the the [imageAssets](api/assets#imageAssets) property.
  *
  * ```js
  * import { loadImage } from 'kontra';
@@ -287,9 +287,9 @@ export function loadImage(url) {
 }
 
 /**
- * Load a single Audio asset. Supports loading multiple audio formats which the loader will use to load the first audio format supported by the browser in the order listed. Uses the base [audio path](api/assets/#setAudioPath) to resolve the URL.
+ * Load a single Audio asset. Supports loading multiple audio formats which the loader will use to load the first audio format supported by the browser in the order listed. Uses the base [audio path](api/assets#setAudioPath) to resolve the URL.
  *
- * Once loaded, the asset will be accessible on the the [audioAssets](api/assets/#audioAssets) property. Since the loader determines which audio asset to load based on browser support, you should only reference the audio by its name and not by its file path since there's no guarantee which asset was loaded.
+ * Once loaded, the asset will be accessible on the the [audioAssets](api/assets#audioAssets) property. Since the loader determines which audio asset to load based on browser support, you should only reference the audio by its name and not by its file path since there's no guarantee which asset was loaded.
  *
  * ```js
  * import { loadAudio, audioAssets } from 'kontra';
@@ -349,9 +349,9 @@ export function loadAudio(url) {
 }
 
 /**
- * Load a single Data asset. Uses the base [data path](api/assets/#setDataPath) to resolve the URL.
+ * Load a single Data asset. Uses the base [data path](api/assets#setDataPath) to resolve the URL.
  *
- * Once loaded, the asset will be accessible on the the [dataAssets](api/assets/#dataAssets) property.
+ * Once loaded, the asset will be accessible on the the [dataAssets](api/assets#dataAssets) property.
  *
  * ```js
  * import { loadData } from 'kontra';
@@ -389,7 +389,7 @@ export function loadData(url) {
 }
 
 /**
- * Load Image, Audio, or data files. Uses the [loadImage](api/assets/#loadImage), [loadAudio](api/assets/#loadAudio), and [loadData](api/assets/#loadData) functions to load each asset type.
+ * Load Image, Audio, or data files. Uses the [loadImage](api/assets#loadImage), [loadAudio](api/assets#loadAudio), and [loadData](api/assets#loadData) functions to load each asset type.
  *
  * ```js
  * import { load } from 'kontra';

--- a/src/keyboard.js
+++ b/src/keyboard.js
@@ -18,7 +18,7 @@
  */
 
 /**
- * Below is a list of keys that are provided by default. If you need to extend this list, you can use the [keyMap](api/keyboard/#keyMap) property.
+ * Below is a list of keys that are provided by default. If you need to extend this list, you can use the [keyMap](api/keyboard#keyMap) property.
  *
  * - a-z
  * - 0-9
@@ -30,7 +30,7 @@ let callbacks = {};
 let pressedKeys = {};
 
 /**
- * A map of keycodes to key names. Add to this object to expand the list of [available keys](api/keyboard/#available-keys).
+ * A map of keycodes to key names. Add to this object to expand the list of [available keys](api/keyboard#available-keys).
  *
  * ```js
  * import { keyMap, bindKeys } from 'kontra';

--- a/src/pool.js
+++ b/src/pool.js
@@ -114,7 +114,7 @@ class Pool {
   }
 
   /**
-   * Clear the object pool. Removes all objects from the pool and resets its [size](api/pool/#size) to 1.
+   * Clear the object pool. Removes all objects from the pool and resets its [size](api/pool#size) to 1.
    * @memberof Pool
    * @function clear
    */

--- a/src/sprite.js
+++ b/src/sprite.js
@@ -236,7 +236,7 @@ class Sprite {
   }
 
   /**
-   * An object of [Animations](api/animation) from a kontra.SpriteSheet to animate the sprite. Each animation is named so that it can can be used by name for the sprites [playAnimation()](api/sprite/#playAnimation) function.
+   * An object of [Animations](api/animation) from a kontra.SpriteSheet to animate the sprite. Each animation is named so that it can can be used by name for the sprites [playAnimation()](api/sprite#playAnimation) function.
    *
    * ```js
    * import { Sprite, SpriteSheet } from 'kontra';
@@ -288,7 +288,7 @@ class Sprite {
   }
 
   /**
-   * The width of the sprite. If the sprite is a [rectangle sprite](api/sprite/#rectangle-sprite), it uses the passed in value. For an [image sprite](api/sprite/#image-sprite) it is the width of the image. And for an [animation sprite](api/sprite/#animation-sprite) it is the width of a single frame of the animation.
+   * The width of the sprite. If the sprite is a [rectangle sprite](api/sprite#rectangle-sprite), it uses the passed in value. For an [image sprite](api/sprite#image-sprite) it is the width of the image. And for an [animation sprite](api/sprite#animation-sprite) it is the width of a single frame of the animation.
    *
    * Setting the value to a negative number will result in the sprite being flipped across the vertical axis while the width will remain a positive value.
    * @memberof Sprite
@@ -299,7 +299,7 @@ class Sprite {
   }
 
   /**
-   * The height of the sprite. If the sprite is a [rectangle sprite](api/sprite/#rectangle-sprite), it uses the passed in value. For an [image sprite](api/sprite/#image-sprite) it is the height of the image. And for an [animation sprite](api/sprite/#animation-sprite) it is the height of a single frame of the animation.
+   * The height of the sprite. If the sprite is a [rectangle sprite](api/sprite#rectangle-sprite), it uses the passed in value. For an [image sprite](api/sprite#image-sprite) it is the height of the image. And for an [animation sprite](api/sprite#animation-sprite) it is the height of a single frame of the animation.
    *
    * Setting the value to a negative number will result in the sprite being flipped across the horizontal axis while the height will remain a positive value.
    * @memberof Sprite
@@ -377,14 +377,14 @@ class Sprite {
    * @memberof Sprite
    * @function isAlive
    *
-   * @returns {Boolean} `true` if the sprites [ttl](api/sprite/#ttl) property is above `0`, `false` otherwise.
+   * @returns {Boolean} `true` if the sprites [ttl](api/sprite#ttl) property is above `0`, `false` otherwise.
    */
   isAlive() {
     return this.ttl > 0;
   }
 
   /**
-   * Check if the sprite collide with the object. Uses a simple [Axis-Aligned Bounding Box (AABB) collision check](https://developer.mozilla.org/en-US/docs/Games/Techniques/2D_collision_detection#Axis-Aligned_Bounding_Box). Takes into account the sprites [anchor](api/sprite/#anchor).
+   * Check if the sprite collide with the object. Uses a simple [Axis-Aligned Bounding Box (AABB) collision check](https://developer.mozilla.org/en-US/docs/Games/Techniques/2D_collision_detection#Axis-Aligned_Bounding_Box). Takes into account the sprites [anchor](api/sprite#anchor).
    *
    * **NOTE:** Does not take into account sprite rotation. If you need collision detection between rotated sprites you will need to implement your own `collidesWith()` function. I suggest looking at the Separate Axis Theorem.
    *
@@ -468,7 +468,7 @@ class Sprite {
   }
 
   /**
-   * Update the sprites position based on its velocity and acceleration. Calls the sprites [advance()](api/sprite/#advance) function.
+   * Update the sprites position based on its velocity and acceleration. Calls the sprites [advance()](api/sprite#advance) function.
    * @memberof Sprite
    * @function update
    *
@@ -479,7 +479,7 @@ class Sprite {
   }
 
   /**
-   * Render the sprite. Calls the sprites [draw()](api/sprite/#draw) function.
+   * Render the sprite. Calls the sprites [draw()](api/sprite#draw) function.
    * @memberof Sprite
    * @function render
    */
@@ -527,9 +527,9 @@ class Sprite {
   }
 
   /**
-   * Move the sprite by its acceleration and velocity. If the sprite is an [animation sprite](api/sprite/#animation-sprite), it also advances the animation every frame.
+   * Move the sprite by its acceleration and velocity. If the sprite is an [animation sprite](api/sprite#animation-sprite), it also advances the animation every frame.
    *
-   * If you override the sprites [update()](api/sprite/#update) function with your own update function, you can call this function to move the sprite normally.
+   * If you override the sprites [update()](api/sprite#update) function with your own update function, you can call this function to move the sprite normally.
    *
    * ```js
    * import { Sprite } from 'kontra';
@@ -575,7 +575,7 @@ class Sprite {
   }
 
   /**
-   * Draw the sprite at its X and Y position. This function changes based on the type of the sprite. For a [rectangle sprite](api/sprite/#rectangle-sprite), it uses `context.fillRect()`, for an [image sprite](api/sprite/#image-sprite) it uses `context.drawImage()`, and for an [animation sprite](api/sprite/#animation-sprite) it uses the [currentAnimation](api/sprite/#currentAnimation) `render()` function.
+   * Draw the sprite at its X and Y position. This function changes based on the type of the sprite. For a [rectangle sprite](api/sprite#rectangle-sprite), it uses `context.fillRect()`, for an [image sprite](api/sprite#image-sprite) it uses `context.drawImage()`, and for an [animation sprite](api/sprite#animation-sprite) it uses the [currentAnimation](api/sprite#currentAnimation) `render()` function.
    *
    * If you override the sprites `render()` function with your own render function, you can call this function to draw the sprite normally.
    *

--- a/src/spriteSheet.js
+++ b/src/spriteSheet.js
@@ -40,7 +40,7 @@ function parseFrames(consecutiveFrames) {
 }
 
 /**
- * A sprite sheet to animate a sequence of images. Used to create [animation sprites](api/sprite/#animation-sprite).
+ * A sprite sheet to animate a sequence of images. Used to create [animation sprites](api/sprite#animation-sprite).
  *
  * <figure>
  *   <a href="assets/imgs/character_walk_sheet.png">
@@ -86,7 +86,7 @@ function parseFrames(consecutiveFrames) {
  * @param {Number} properties.frameWidth - The width of a single frame.
  * @param {Number} properties.frameHeight - The height of a single frame.
  * @param {Number} [properties.frameMargin=0] - The amount of whitespace between each frame.
- * @param {Object} [properties.animations] - Animations to create from the sprite sheet using kontra.Animation. Passed directly into the sprite sheets [createAnimations()](api/spriteSheet/#createAnimations) function.
+ * @param {Object} [properties.animations] - Animations to create from the sprite sheet using kontra.Animation. Passed directly into the sprite sheets [createAnimations()](api/spriteSheet#createAnimations) function.
  */
 class SpriteSheet {
   constructor({image, frameWidth, frameHeight, frameMargin, animations} = {}) {
@@ -97,7 +97,7 @@ class SpriteSheet {
     // @endif
 
     /**
-     * An object of named kontra.Animation objects. Typically you pass this object into kontra.Sprite to create an [animation sprites](api/spriteSheet/#animation-sprite).
+     * An object of named kontra.Animation objects. Typically you pass this object into kontra.Sprite to create an [animation sprites](api/spriteSheet#animation-sprite).
      * @memberof SpriteSheet
      * @property {Object} animations
      */

--- a/src/tileEngine.js
+++ b/src/tileEngine.js
@@ -20,11 +20,11 @@ import { getCanvas, getContext } from './core.js'
  *
  * @param {Object[]} properties.tilesets - Array of tileset objects.
  * @param {Number} properties.tilesetN.firstgid - First tile index of the tileset. The first tileset will have a firstgid of 1 as 0 represents an empty tile.
- * @param {String|HTMLImageElement} properties.tilesetN.image - Relative path to the HTMLImageElement or an HTMLImageElement. If passing a relative path, the image file must have been [loaded](api/assets/#load) first.
+ * @param {String|HTMLImageElement} properties.tilesetN.image - Relative path to the HTMLImageElement or an HTMLImageElement. If passing a relative path, the image file must have been [loaded](api/assets#load) first.
  * @param {Number} [properties.tilesetN.margin=0] - The amount of whitespace between each tile (in pixels).
  * @param {Number} [properties.tilesetN.tilewidth] - Width of the tileset (in pixels). Defaults to properties.tilewidth.
  * @param {Number} [properties.tilesetN.tileheight] - Height of the tileset (in pixels). Defaults to properties.tileheight.
- * @param {String} [properties.tilesetN.source] - Relative path to the source JSON file. The source JSON file must have been [loaded](api/assets/#load) first.
+ * @param {String} [properties.tilesetN.source] - Relative path to the source JSON file. The source JSON file must have been [loaded](api/assets#load) first.
  * @param {Number} [properties.tilesetN.columns] - Number of columns in the tileset image.
  *
  * @param {Object[]} properties.layers - Array of layer objects.
@@ -186,18 +186,18 @@ export default function TileEngine(properties = {}) {
     renderLayer(name) {
       let canvas = layerCanvases[name];
       let layer = layerMap[name];
-      
+
       if (!canvas) {
         // cache the rendered layer so we can render it again without redrawing
         // all tiles
         canvas = document.createElement('canvas');
         canvas.width = mapwidth;
         canvas.height = mapheight;
-        
+
         layerCanvases[name] = canvas;
         tileEngine._r(layer, canvas.getContext('2d'));
       }
-      
+
       if (this._d) {
         this._d = false;
         canvas.getContext('2d').clearRect(0, 0, canvas.width, canvas.height);


### PR DESCRIPTION
I found a few URLs in the documentation that are broken because the anchor is behind a /. For example, the first link in the [SpriteSheet documentation](https://straker.github.io/kontra/api/spriteSheet). If you replace `/#` in the URLs with `#`, the links work.

I ran a regex on the src code comments to fix these errors.