### PR TITLE
When an object layer tries to be rendered, engine fails.

### DIFF
--- a/src/tileEngine.js
+++ b/src/tileEngine.js
@@ -526,7 +526,7 @@ export default function TileEngine(properties = {}) {
     context.save();
     context.globalAlpha = layer.opacity;
 
-    layer.data.map((tile, index) => {
+    (layer.data || []).map((tile, index) => {
 
       // skip empty tiles (0)
       if (!tile) return;


### PR DESCRIPTION
I use an object layer to save the position of some elements, but when the tile engine tries to render it, it fails because the data property does not exist.

This was the simples fix I could think of. Let me know if there's a better fix for this.