### PR TITLE
Passing dt to GameObject children update

### DIFF
--- a/src/gameObject.js
+++ b/src/gameObject.js
@@ -264,7 +264,7 @@ class GameObject extends Updatable {
     this._uf(dt);
 
     // @ifdef GAMEOBJECT_GROUP
-    this.children.map(child => child.update && child.update());
+    this.children.map(child => child.update && child.update(dt));
     // @endif
   }
 


### PR DESCRIPTION
Thank you for such amazing library. It has almost everything to get started with game development on JavaScript while keeping everything simple.

While testing extending a `GameObject`, and using groups, I noticed that the `dt` parameter was not passed to the children of the object. Even though the `dt` parameter is optional please consider to passed down to the object children for consistency.

Any feedback on the proposed fix is welcomed.