### PR TITLE
feat(button): button can be disabled when created

### DIFF
--- a/src/button.js
+++ b/src/button.js
@@ -86,8 +86,6 @@ class Button extends Sprite.class {
 
     if (disabled) {
       this.disable();
-    } else {
-      this.enable();
     }
 
     // sync events between the button element and the class

--- a/src/button.js
+++ b/src/button.js
@@ -10,6 +10,7 @@ import { srOnlyStyle, noop, addToDom } from './utils.js';
  *
  * @param {Object} [properties] - Properties of the button (in addition to all Sprite properties).
  * @param {Object} [properties.text] - Properties of [Text](api/text) which are used to create the [textNode](api/button#textNode).
+ * @param {Boolean} [properties.disabled] - Whether the button is disabled when created.
  * @param {Number} [properties.padX=0] - The horizontal padding.
  * @param {Number} [properties.padY=0] - The vertical padding.
  * @param {Function} [properties.onEnable] - Function called when the button is enabled.
@@ -38,6 +39,7 @@ class Button extends Sprite.class {
     padY = 0,
 
     text,
+    disabled = false,
     onDown,
     onUp,
     ...props
@@ -81,6 +83,13 @@ class Button extends Sprite.class {
     const button = this._dn = document.createElement('button');
     button.style = srOnlyStyle;
     button.textContent = this.text;
+
+    /**
+     * If the button is disabled.
+     * @memberof Button
+     * @property {Boolean} disabled
+     */
+    this.disabled = this._dn.disabled = disabled;
 
     // sync events between the button element and the class
     button.addEventListener('focus', () => this.focus());
@@ -150,12 +159,6 @@ class Button extends Sprite.class {
    * @function enable
    */
   enable() {
-
-    /**
-     * If the button is disabled.
-     * @memberof Button
-     * @property {Boolean} disabled
-     */
     this.disabled = this._dn.disabled = false;
     this.onEnable();
   }
@@ -225,28 +228,28 @@ class Button extends Sprite.class {
    * @memberof Button
    * @function onEnable
    */
-  onEnable() {}
+  onEnable() { }
 
   /**
    * Function called when then button is disabled. Override this function to have the button do something when disabled.
    * @memberof Button
    * @function onDisable
    */
-  onDisable() {}
+  onDisable() { }
 
   /**
    * Function called when then button is focused. Override this function to have the button do something when focused.
    * @memberof Button
    * @function onFocus
    */
-  onFocus() {}
+  onFocus() { }
 
   /**
    * Function called when then button is blurred. Override this function to have the button do something when blurred.
    * @memberof Button
    * @function onBlur
    */
-  onBlur() {}
+  onBlur() { }
 
   onDown() {
     if (!this.disabled) {

--- a/src/button.js
+++ b/src/button.js
@@ -84,12 +84,11 @@ class Button extends Sprite.class {
     button.style = srOnlyStyle;
     button.textContent = this.text;
 
-    /**
-     * If the button is disabled.
-     * @memberof Button
-     * @property {Boolean} disabled
-     */
-    this.disabled = this._dn.disabled = disabled;
+    if (disabled) {
+      this.disable();
+    } else {
+      this.enable();
+    }
 
     // sync events between the button element and the class
     button.addEventListener('focus', () => this.focus());
@@ -159,6 +158,11 @@ class Button extends Sprite.class {
    * @function enable
    */
   enable() {
+    /**
+     * If the button is disabled.
+     * @memberof Button
+     * @property {Boolean} disabled
+     */
     this.disabled = this._dn.disabled = false;
     this.onEnable();
   }

--- a/test/unit/button.spec.js
+++ b/test/unit/button.spec.js
@@ -35,7 +35,6 @@ describe('button', () => {
 
       expect(button.padX).to.equal(0);
       expect(button.padY).to.equal(0);
-      expect(button.disabled).to.be.false;
       expect(button.textNode instanceof Text).to.be.true;
     });
 

--- a/test/unit/button.spec.js
+++ b/test/unit/button.spec.js
@@ -35,6 +35,7 @@ describe('button', () => {
 
       expect(button.padX).to.equal(0);
       expect(button.padY).to.equal(0);
+      expect(button.disabled).to.be.false;
       expect(button.textNode instanceof Text).to.be.true;
     });
 
@@ -55,6 +56,16 @@ describe('button', () => {
       expect(button.textNode.font).to.equal('32px Arial');
       expect(button.textNode.text).to.equal('Hello');
       expect(button.textNode.color).to.equal('black');
+    });
+
+
+    it('should start disabled if specified', () => {
+      button.destroy()
+      button = Button({
+        disabled: true
+      });
+
+      expect(button.disabled).to.be.true;
     });
 
     it('should default width to the text size', () => {
@@ -97,7 +108,7 @@ describe('button', () => {
 
     it('should pass the context to the textNode', () => {
       let canvas = document.createElement('canvas');
-      initPointer({canvas});
+      initPointer({ canvas });
       let context = canvas.getContext('2d');
 
       button.destroy()
@@ -122,7 +133,7 @@ describe('button', () => {
     it('should hide the DOM node', () => {
       srOnlyStyle.split(';').forEach(style => {
         let parts = style.split(':');
-        expect(button._dn.style[ parts[0] ]).to.equal(parts[1]);
+        expect(button._dn.style[parts[0]]).to.equal(parts[1]);
       });
     });
 
@@ -160,7 +171,7 @@ describe('button', () => {
       // @see https://github.com/ariya/phantomjs/issues/11289#issuecomment-38880333
       try {
         evt = new Event(type);
-      } catch(e) {
+      } catch (e) {
         evt = document.createEvent('Event');
         evt.initEvent(type, true, false);
       }
@@ -180,21 +191,21 @@ describe('button', () => {
 
       it('should call onDown if Enter is pressed', () => {
         sinon.spy(button, 'onDown');
-        simulateEvent('keydown', {code: 'Enter'});
+        simulateEvent('keydown', { code: 'Enter' });
 
         expect(button.onDown.called).to.be.true;
       });
 
       it('should call onDown if Space is pressed', () => {
         sinon.spy(button, 'onDown');
-        simulateEvent('keydown', {code: 'Space'});
+        simulateEvent('keydown', { code: 'Space' });
 
         expect(button.onDown.called).to.be.true;
       });
 
       it('should not call onDown if any other key is pressed', () => {
         sinon.spy(button, 'onDown');
-        simulateEvent('keydown', {code: 'KeyA'});
+        simulateEvent('keydown', { code: 'KeyA' });
 
         expect(button.onDown.called).to.be.false;
       });
@@ -211,21 +222,21 @@ describe('button', () => {
 
       it('should call onUp if Enter is pressed', () => {
         sinon.spy(button, 'onUp');
-        simulateEvent('keyup', {code: 'Enter'});
+        simulateEvent('keyup', { code: 'Enter' });
 
         expect(button.onUp.called).to.be.true;
       });
 
       it('should call onUp if Space is pressed', () => {
         sinon.spy(button, 'onUp');
-        simulateEvent('keyup', {code: 'Space'});
+        simulateEvent('keyup', { code: 'Space' });
 
         expect(button.onUp.called).to.be.true;
       });
 
       it('should not call onUp if any other key is pressed', () => {
         sinon.spy(button, 'onUp');
-        simulateEvent('keyup', {code: 'KeyA'});
+        simulateEvent('keyup', { code: 'KeyA' });
 
         expect(button.onUp.called).to.be.false;
       });


### PR DESCRIPTION
Closes #241 

Allows buttons to be disabled when created by passing in a `disabled` property like so:
```js
let button = Button({
  disabled: true
});
```

By default, the `disabled` property is `false`.