### PR TITLE
Cast value to string when setting Text.text

### DIFF
--- a/src/text.js
+++ b/src/text.js
@@ -161,7 +161,7 @@ class Text extends GameObject.class {
 
   set text(value) {
     this._d = true;
-    this._t = value;
+    this._t = '' + value;
   }
 
   get font() {

--- a/test/unit/text.spec.js
+++ b/test/unit/text.spec.js
@@ -72,6 +72,14 @@ describe('text with context: ' + JSON.stringify(testContext,null,4), () => {
 
       expect(text._d).to.be.true;
     });
+    
+    it('should cast the value when setting text', () => {
+      let text = Text({text: ''});
+
+      text.text = 123;
+
+      expect(text.text).to.equal('123');
+    });
 
     it('should set the text as dirty when setting width', () => {
       let text = Text({text: ''});


### PR DESCRIPTION
fixes #239 

Doesn't seem like the best `describe` block for the test but didn't want to be too invasive for this change