### PR TITLE
fix(grid): work with colSpan > 2

### DIFF
--- a/karma.debug.js
+++ b/karma.debug.js
@@ -1,0 +1,34 @@
+module.exports = function (config) {
+  config.set({
+    basePath: '',
+    singleRun: false,
+    autoWatch: true,
+    frameworks: ['mocha', 'chai', 'sinon'],
+    files: [
+      // setup
+      { pattern: 'test/setup.js', type: 'module' },
+
+      // assets
+      { pattern: 'test/imgs/*.*', included: false, served: true },
+      { pattern: 'test/audio/*.*', included: false, served: true },
+      { pattern: 'test/data/*.*', included: false, served: true },
+
+      { pattern: 'src/*.js', type: 'module', included: false },
+      { pattern: 'test/unit/*.spec.js', type: 'module' },
+      { pattern: 'test/integration/*.spec.js', type: 'module' }
+    ],
+    browsers: ['Chrome'],
+    proxies: {
+      '/imgs': '/base/test/imgs',
+      '/audio': '/base/test/audio',
+      '/data': '/base/test/data'
+    },
+    reporters: ['mocha'],
+    client: {
+      mocha: {
+        timeout: 4000,
+        reporter: 'html'
+      }
+    }
+  });
+};

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "test:watch": "karma start",
     "test:permutations": "node test/permutations",
     "test:ts": "tsc test/typings/*.ts",
+    "test:debug": "karma start karma.debug.js",
     "build": "gulp build",
     "build:docs": "gulp build:docs",
     "dist": "gulp dist",

--- a/src/grid.js
+++ b/src/grid.js
@@ -231,10 +231,11 @@ class Grid extends GameObjectClass {
 
       let spans = child.colSpan || 1;
       let colSpan = spans;
+
       do {
         colWidths[col] = Math.max(colWidths[col] || 0, child.width / colSpan);
         grid[row][col] = child;
-      } while (colSpan + col++ <= numCols && --spans);
+      } while (col++ <= numCols && --spans);
 
       if (col >= numCols) {
         col = 0;

--- a/test/unit/grid.spec.js
+++ b/test/unit/grid.spec.js
@@ -637,7 +637,6 @@ describe('grid', () => {
         grid = Grid({
           x: 100,
           y: 50,
-          flow: 'grid',
           colGap: [5, 10, 15],
           flow: 'row',
           children: [child1, child2, child3, child4]
@@ -731,6 +730,25 @@ describe('grid', () => {
 
         expect(child4.x).to.equal(75);
         expect(child4.y).to.equal(125);
+      });
+
+      it('should work for colSpan > 2', () => {
+        child1.colSpan = 4;
+        grid.numCols = 4;
+        grid._d = true;
+        grid.render();
+
+        expect(child1.x).to.equal(0);
+        expect(child1.y).to.equal(0);
+
+        expect(child2.x).to.equal(0);
+        expect(child2.y).to.equal(25);
+
+        expect(child3.x).to.equal(25);
+        expect(child3.y).to.equal(25);
+
+        expect(child4.x).to.equal(75);
+        expect(child4.y).to.equal(25);
       });
     });
 

--- a/test/unit/pointer.spec.js
+++ b/test/unit/pointer.spec.js
@@ -42,7 +42,7 @@ describe('pointer', () => {
     // reset canvas offsets
     canvas = getCanvas();
     canvas.width = canvas.height = 600;
-    canvas.style.position = 'absolute';
+    canvas.style.position = 'fixed';
     canvas.style.top = 0;
     canvas.style.left = 0;
 
@@ -579,7 +579,7 @@ describe('pointer', () => {
         let canvas = document.createElement('canvas');
         document.body.appendChild(canvas);
         canvas.width = canvas.height = 600;
-        canvas.style.position = 'absolute';
+        canvas.style.position = 'fixed';
         canvas.style.top = 0;
         canvas.style.left = 0;
 
@@ -738,7 +738,7 @@ describe('pointer', () => {
           let canvas = document.createElement('canvas');
           document.body.appendChild(canvas);
           canvas.width = canvas.height = 600;
-          canvas.style.position = 'absolute';
+          canvas.style.position = 'fixed';
           canvas.style.top = 0;
           canvas.style.left = 0;
 


### PR DESCRIPTION
Also adds a way to debug tests in the browser using `npm run test:debug` (and fixes pointer tests to work in the browser debug view).

Closes #240 