### PR TITLE
Fix docs showing how to access underlying class

### DIFF
--- a/docs/api_docs/gameObject.js
+++ b/docs/api_docs/gameObject.js
@@ -1,7 +1,7 @@
 /**
  * A GameObject is just a base class and typically isn't used directly. Instead, it's main purpose is to be extended by other classes, such as [Sprite](/api/sprite).
  *
- * To extend the GameObject class, import the underlying class as import {GameObjectClass}.
+ * To extend the GameObject class, access the underlying class as `GameObject.class`.
  *
  * You should also override the `draw()` function instead of the `render()` function in your class. The `draw()` function determines how to draw the GameObject. It is called by the `render` function after transforms and rotations have been applied.
  *
@@ -10,13 +10,13 @@
  * @sectionName Extending A GameObject
  * @example
  * // exclude-code:start
- * let { GameObjectClass } = kontra;
+ * let { GameObject } = kontra;
  * // exclude-code:end
  * // exclude-script:start
- * import { GameObjectClass } from 'kontra';
+ * import { GameObject } from 'kontra';
  * // exclude-script:end
  *
- * class Triangle extends GameObject {
+ * class Triangle extends GameObject.class {
  *   constructor(properties) {
  *     super(properties);
  *   }

--- a/docs/api_docs/plugin.js
+++ b/docs/api_docs/plugin.js
@@ -22,10 +22,10 @@
  *
  * ```js
  * // consumerCode.js
- * import { registerPlugin, Sprite, SpriteClass, collides } from 'kontra';
+ * import { registerPlugin, Sprite, collides } from 'kontra';
  * import loggingPlugin from pluginCode.js;
  *
- * class SpriteBox extends SpriteClass {
+ * class SpriteBox extends Sprite.class {
  *   constructor(props) {
  *     super(props);
  *   }

--- a/docs/api_docs/sprite.js
+++ b/docs/api_docs/sprite.js
@@ -161,16 +161,16 @@
  */
 
 /**
- * If you want to extend a Sprite, you can do so by extending the Sprite class. The one caveat is that `Sprite` is not the Sprite class, but actually is a factory function. To extend the Sprite class, import `SpriteClass` from kontra.
+ * If you want to extend a Sprite, you can do so by extending the Sprite class. The one caveat is that `Sprite` is not the Sprite class, but actually is a factory function. To extend the Sprite class, access the underlying class as `Sprite.class`.
  *
  * You should also override the `draw()` function instead of the `render()` function in your class. The `draw()` function determines how to draw the Sprite. It is called by the `render` function after transforms and rotations have been applied.
  *
  * Do note that the canvas has been rotated and translated to the objects position (taking into account anchor), so {0,0} will be the top-left corner of the game object when drawing.
  *
  * ```js
- * import { Sprite, SpriteClass } from 'kontra';
+ * import { Sprite } from 'kontra';
  *
- * class CustomSprite extends SpriteClass {
+ * class CustomSprite extends Sprite.class {
  *   constructor(properties) {
  *     super(properties);
  *     this.myProp = properties.myProp;

--- a/src/plugin.js
+++ b/src/plugin.js
@@ -6,7 +6,7 @@
  * import loggingPlugin from 'path/to/plugin/code.js'
  *
  * // register a plugin that adds logging to all Sprites
- * registerPlugin(Sprite, loggingPlugin);
+ * registerPlugin(Sprite.class, loggingPlugin);
  * ```
  * @sectionName Plugin
  */


### PR DESCRIPTION
The way you access a class internally (`GameObjectClass`) is removed in the final files and is instead accessed via `GameObject.class`. I've found all the places that shows extending a class and updated them.