### PR TITLE
feat(input): add input wraper api, rename `up`, `down`, `left`, `right` keyboard names to `arrowup`, `arrowdown`, `arrowleft`,  `arrowright`

### DIFF
--- a/examples/galaxian/js/galaxian.js
+++ b/examples/galaxian/js/galaxian.js
@@ -134,15 +134,15 @@ function getGameScene() {
     update: function () {
       this.counter++;
 
-      if (kontra.keyPressed('left')) {
+      if (kontra.keyPressed('arrowleft')) {
         this.x -= 3;
-      } else if (kontra.keyPressed('right')) {
+      } else if (kontra.keyPressed('arrowright')) {
         this.x += 3;
       }
 
-      if (kontra.keyPressed('up')) {
+      if (kontra.keyPressed('arrowup')) {
         this.y -= 3;
-      } else if (kontra.keyPressed('down')) {
+      } else if (kontra.keyPressed('arrowdown')) {
         this.y += 3;
       }
 

--- a/examples/pointer/tracking.html
+++ b/examples/pointer/tracking.html
@@ -85,7 +85,7 @@
     });
 
     // create a sprites
-    onPointer('down', function(evt) {
+    onPointer('arrowdown', function(evt) {
       try {
         if (pointer.touches) {
           console.log(JSON.stringify(pointer.touches));

--- a/examples/scene/snake.js
+++ b/examples/scene/snake.js
@@ -65,7 +65,7 @@ let snake = kontra.Sprite({
 // not already moving on the same axis (pressing left while moving
 // left won't do anything, and pressing right while moving left
 // shouldn't let you collide with your own body)
-kontra.onKey('left', () => {
+kontra.onKey('arrowleft', () => {
   if (snake.dx === 0) {
     // queue the move so we also don't change directions before an
     // update and still can run into ourselves
@@ -75,7 +75,7 @@ kontra.onKey('left', () => {
     });
   }
 });
-kontra.onKey('up', () => {
+kontra.onKey('arrowup', () => {
   if (snake.dy === 0) {
     snake.queue.push({
       dy: -gridSize,
@@ -83,13 +83,13 @@ kontra.onKey('up', () => {
     });
   }
 });
-kontra.onKey('right', () => {
+kontra.onKey('arrowright', () => {
   snake.queue.push({
     dx: gridSize,
     dy: 0
   });
 });
-kontra.onKey('down', () => {
+kontra.onKey('arrowdown', () => {
   if (snake.dy === 0) {
     snake.queue.push({
       dy: gridSize,

--- a/examples/sprite/clampSpriteMovement.html
+++ b/examples/sprite/clampSpriteMovement.html
@@ -24,24 +24,24 @@
       // pass a custom update function to the sprite
       update: function() {
         // move the sprite with the keyboard
-        if (kontra.keyPressed('up')) {
+        if (kontra.keyPressed('arrowup')) {
           this.y -= this.dy;
         }
-        else if (kontra.keyPressed('down')) {
+        else if (kontra.keyPressed('arrowdown')) {
           this.y += this.dy;
         }
 
-        if (kontra.keyPressed('left')) {
+        if (kontra.keyPressed('arrowleft')) {
           this.x -= this.dx;
         }
-        else if (kontra.keyPressed('right')) {
+        else if (kontra.keyPressed('arrowright')) {
           this.x += this.dx;
         }
       }
     });
 
     // prevent default key behavior
-    kontra.onKey(['up', 'down', 'left', 'right'], function(e) {
+    kontra.onKey(['arrowup', 'arrowdown', 'arrowleft', 'arrowright'], function(e) {
       e.preventDefault();
     });
 

--- a/examples/sprite/controllingASprite.html
+++ b/examples/sprite/controllingASprite.html
@@ -24,17 +24,17 @@
       // pass a custom update function to the sprite
       update: function() {
         // move the sprite with the keyboard
-        if (kontra.keyPressed('up')) {
+        if (kontra.keyPressed('arrowup')) {
           this.y -= this.dy;
         }
-        else if (kontra.keyPressed('down')) {
+        else if (kontra.keyPressed('arrowdown')) {
           this.y += this.dy;
         }
 
-        if (kontra.keyPressed('left')) {
+        if (kontra.keyPressed('arrowleft')) {
           this.x -= this.dx;
         }
-        else if (kontra.keyPressed('right')) {
+        else if (kontra.keyPressed('arrowright')) {
           this.x += this.dx;
         }
 
@@ -56,11 +56,11 @@
     });
 
     // prevent default key behavior
-    kontra.onKey(['up', 'down', 'left', 'right'], function(e) {
+    kontra.onKey(['arrowup', 'arrowdown', 'arrowleft', 'arrowright'], function(e) {
       e.preventDefault();
     });
 
-    kontra.onKey(['up', 'down', 'left', 'right'], function(e) {
+    kontra.onKey(['arrowup', 'arrowdown', 'arrowleft', 'arrowright'], function(e) {
       console.log('key released: ', e)
     }, 'keyup');
 

--- a/examples/tileEngine/camera/index.html
+++ b/examples/tileEngine/camera/index.html
@@ -77,7 +77,7 @@
           height: 22
         };
 
-        if (kontra.keyPressed('up')) {
+        if (kontra.keyPressed('arrowup')) {
           this.playAnimation('walk_up');
           collisionBox.y -= this.speed;
 
@@ -94,7 +94,7 @@
             tileEngine.sy -= this.speed;
           }
         }
-        else if (kontra.keyPressed('down')) {
+        else if (kontra.keyPressed('arrowdown')) {
           this.playAnimation('walk_down');
           collisionBox.y += this.speed;
 
@@ -111,7 +111,7 @@
             tileEngine.sy += this.speed;
           }
         }
-        else if (kontra.keyPressed('left')) {
+        else if (kontra.keyPressed('arrowleft')) {
           this.playAnimation('walk_left');
           collisionBox.x -= this.speed;
 
@@ -128,7 +128,7 @@
             tileEngine.sx -= this.speed;
           }
         }
-        else if (kontra.keyPressed('right')) {
+        else if (kontra.keyPressed('arrowright')) {
           this.playAnimation('walk_right');
           collisionBox.x += this.speed;
 

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -18,6 +18,7 @@ module.exports = function (config) {
       { pattern: 'test/data/**/*.*', included: false, served: true },
 
       { pattern: 'src/*.js', type: 'module', included: false },
+      { pattern: 'test/utils.js', type: 'module', included: false },
       { pattern: 'test/unit/*.spec.js', type: 'module' },
       { pattern: 'test/integration/*.spec.js', type: 'module' }
     ],

--- a/src/gamepad.js
+++ b/src/gamepad.js
@@ -222,7 +222,7 @@ export function initGamepad() {
  * ```
  * @function onGamepad
  *
- * @param {String|String[]} buttons - Button or buttons to regsiter callback for.
+ * @param {String|String[]} buttons - Button or buttons to register callback for.
  * @param {(gamepad: Gamepad, button: GamepadButton) => void} callback - The function to be called when the button is pressed.
  * @param {Object} [options] - Register options.
  * @param {Number} [options.gamepad] - Gamepad index. Defaults to registerting for all gamepads.

--- a/src/gamepad.js
+++ b/src/gamepad.js
@@ -107,7 +107,7 @@ function gamepadDisconnectedHandler(event) {
  * Reset pressed buttons and axes information.
  */
 function blurEventHandler() {
-  gamepads.forEach(gamepad => {
+  gamepads.map(gamepad => {
     gamepad.pressedButtons = {};
     gamepad.axes = {};
   });
@@ -150,7 +150,7 @@ export function updateGamepad() {
       continue;
     }
 
-    gamepad.buttons.forEach((button, index) => {
+    gamepad.buttons.map((button, index) => {
       let buttonName = gamepadMap[index];
       let { pressed } = button;
       let { pressedButtons } = gamepads[gamepad.index];

--- a/src/gesture.js
+++ b/src/gesture.js
@@ -107,7 +107,7 @@ export let gestureMap = {
  * Initialize gesture event listeners. This function must be called before using other gesture functions. Gestures depend on pointer events, so [initPointer](api/pointer#initPointer) must be called as well.
  * @function initGesture
  */
-export function initGesture(gestures) {
+export function initGesture() {
   // don't add the on call multiple times otherwise it will mess up
   // gesture events
   if (!init) {

--- a/src/input.js
+++ b/src/input.js
@@ -3,21 +3,85 @@ import { gestureMap, initGesture, onGesture, offGesture } from './gesture.js';
 import { keyMap, initKeys, onKey, offKey } from './keyboard.js';
 import { initPointer, onPointer, offPointer } from './pointer.js';
 
+/**
+ * A wrapper for initializing and handling multiple inputs at once (keyboard, gamepad, gesture, pointer).
+ *
+ * ```js
+ * import { initInput, onInput } from 'kontra';
+ *
+ * // this function must be called first before input
+ * // functions will work
+ * initInput();
+ *
+ * onInput(['arrowleft', 'swipeleft', 'dpadleft'], () => {
+ *   // move left
+ * });
+ * ```
+ * @sectionName Input
+ */
+
+/**
+ * Check if string is a value of an object.
+ * @param {String} value - Value to look for.
+ * @param {Object} map - Object to look in.
+ *
+ * @returns {Boolean} True if the object contains the value, false otherwise.
+ */
 function contains(value, map) {
   return Object.values(map).includes(value);
 }
 
+/**
+ * Check to see if input name is a gesture input.
+ * @param {String} value - Value to look for.
+ *
+ * @returns {Boolean} True if value is a gesture input, false otherwise.
+ */
 function isGesture(value) {
   return Object.keys(gestureMap).some(name => value.startsWith(name));
 }
 
+/**
+ * Initialize input event listeners. This function must be called before using other input functions.
+ * @function initInput
+ *
+ * @param {Object} [options] - Input options.
+ * @param {Object} [options.pointer] - [Pointer options](/api/pointer#initPointer).
+ *
+ * @returns {{pointer: {x: Number, y: Number, radius: Number, canvas: HTMLCanvasElement, touches: Object}}} Object with `pointer` property which is the pointer object for the canvas.
+ */
 export function initInput(options = {}) {
   initKeys();
-  initPointer(options.pointer);
+  let pointer = initPointer(options.pointer);
   initGesture();
   initGamepad();
+
+  return { pointer };
 }
 
+/**
+ * Register a function to be called on an input event. Takes a single input or an array of inputs. See the [keyboard](api/keyboard#available-keys), [gamepad](api/gamepad#available-buttons), [gesture](api/gesture#available-gestures), and [pointer](/api/pointer#onPointer) docs for the lists of available input names.
+ *
+ * ```js
+ * import { initInput, onInput } from 'kontra';
+ *
+ * initInput();
+ *
+ * onInput('p', function(e) {
+ *   // pause the game
+ * });
+ * onInput(['enter', 'down', 'south'], function(e) {
+ *   // fire gun on enter key, mouse down, or gamepad south button
+ * });
+ * ```
+ * @function onInput
+ *
+ * @param {String|String[]} inputs - Inputs or inputs to register callback for.
+ * @param {Function} callback -  The function to be called on the input event.
+ * @param {Object} [options] - Input options.
+ * @param {Object} [options.gamepad] - [onGamepad options](/api/gamepad#onGamepad).
+ * @param {Object} [options.key] - [onKey options](/api/keyboard#onKey).
+ */
 export function onInput(inputs, callback, { gamepad, key } = {}) {
   [].concat(inputs).map(input => {
     if (contains(input, gamepadMap)) {
@@ -37,7 +101,23 @@ export function onInput(inputs, callback, { gamepad, key } = {}) {
   });
 }
 
-export function offInput(inputs, callback, { gamepad, key } = {}) {
+/**
+ * Unregister the callback function for an input. Takes a single input or an array of inputs.
+ *
+ * ```js
+ * import { offInput } from 'kontra';
+ *
+ * offInput('left');
+ * offInput(['enter', 'down', 'swipeleft']);
+ * ```
+ * @function offInput
+ *
+ * @param {String|String[]} inputs - Inputs or inputs to unregister callback for.
+ * @param {Object} [options] - Input options.
+ * @param {Object} [options.gamepad] - [offGamepad options](/api/gamepad#offGamepad).
+ * @param {Object} [options.key] - [offKey options](/api/keyboard#offKey).
+ */
+export function offInput(inputs, { gamepad, key } = {}) {
   [].concat(inputs).map(input => {
     if (contains(input, gamepadMap)) {
       offGamepad(input, gamepad);

--- a/src/input.js
+++ b/src/input.js
@@ -1,0 +1,52 @@
+import { gamepadMap, initGamepad, onGamepad, offGamepad } from './gamepad.js';
+import { gestureMap, initGesture, onGesture, offGesture } from './gesture.js';
+import { keyMap, initKeys, onKey, offKey } from './keyboard.js';
+import { initPointer, onPointer, offPointer } from './pointer.js';
+
+function contains(value, map) {
+  return Object.values(map).includes(value);
+}
+
+function isGesture(value) {
+  return Object.keys(gestureMap).some(name => value.startsWith(name));
+}
+
+export function initInput(options = {}) {
+  initKeys();
+  initPointer(options.pointer);
+  initGesture();
+  initGamepad();
+}
+
+export function onInput(inputs, callback, { gamepad, key } = {}) {
+  [].concat(inputs).map(input => {
+    if (contains(input, gamepadMap)) {
+      onGamepad(input, callback, gamepad);
+    } else if (isGesture(input)) {
+      onGesture(input, callback);
+    } else if (contains(input, keyMap)) {
+      onKey(input, callback, key);
+    } else if (['down', 'up'].includes(input)) {
+      onPointer(input, callback);
+    }
+    // @ifdef DEBUG
+    else {
+      throw new TypeError(`"${input}" is not a valid input name`);
+    }
+    // @endif
+  });
+}
+
+export function offInput(inputs, callback, { gamepad, key } = {}) {
+  [].concat(inputs).map(input => {
+    if (contains(input, gamepadMap)) {
+      offGamepad(input, gamepad);
+    } else if (isGesture(input)) {
+      offGesture(input);
+    } else if (contains(input, keyMap)) {
+      offKey(input, key);
+    } else if (['down', 'up'].includes(input)) {
+      offPointer(input);
+    }
+  });
+}

--- a/src/keyboard.js
+++ b/src/keyboard.js
@@ -164,7 +164,7 @@ export function onKey(keys, callback, { handler = 'keydown', preventDefault = tr
  * ```js
  * import { offKey } from 'kontra';
  *
- * offKey('left');
+ * offKey('arrowleft');
  * offKey(['enter', 'space']);
  * ```
  * @function offKey
@@ -188,17 +188,17 @@ export function offKey(keys, { handler = 'keydown' } = {}) {
  *
  * let sprite = Sprite({
  *   update: function() {
- *     if (keyPressed('left')){
+ *     if (keyPressed('arrowleft')){
  *       // left arrow pressed
  *     }
- *     else if (keyPressed('right')) {
+ *     else if (keyPressed('arrowright')) {
  *       // right arrow pressed
  *     }
  *
- *     if (keyPressed('up')) {
+ *     if (keyPressed('arrowup')) {
  *       // up arrow pressed
  *     }
- *     else if (keyPressed('down')) {
+ *     else if (keyPressed('arrowdown')) {
  *       // down arrow pressed
  *     }
  *   }

--- a/src/keyboard.js
+++ b/src/keyboard.js
@@ -11,7 +11,7 @@ import { noop } from './utils.js';
  * initKeys();
  *
  * function update() {
- *   if (keyPressed('left')) {
+ *   if (keyPressed('arrowleft')) {
  *     // move left
  *   }
  * }
@@ -24,7 +24,7 @@ import { noop } from './utils.js';
  *
  * - a-z
  * - 0-9
- * - enter, esc, space, left, up, right, down
+ * - enter, esc, space, arrowleft, arrowup, arrowright, arrowdown
  * @sectionName Available Keys
  */
 
@@ -112,12 +112,12 @@ export function initKeys() {
   for (i = 0; i < 26; i++) {
     // rollupjs considers this a side-effect (for now), so we'll do it
     // in the initKeys function
-    keyMap[i + 65] = keyMap['Key' + String.fromCharCode(i + 65)] = String.fromCharCode(i + 97);
+    keyMap['Key' + String.fromCharCode(i + 65)] = String.fromCharCode(i + 97);
   }
 
   // numeric keys
   for (i = 0; i < 10; i++) {
-    keyMap[48 + i] = keyMap['Digit' + i] = '' + i;
+    keyMap['Digit' + i] = keyMap['Numpad' + i] = '' + i;
   }
 
   window.addEventListener('keydown', keydownEventHandler);
@@ -137,7 +137,7 @@ export function initKeys() {
  *
  * onKey('p', function(e) {
  *   // pause the game
- * }, 'keyup');
+ * });
  * onKey(['enter', 'space'], function(e) {
  *   // fire gun
  * });
@@ -175,8 +175,7 @@ export function onKey(keys, callback, { handler = 'keydown', preventDefault = tr
  */
 export function offKey(keys, { handler = 'keydown' } = {}) {
   let callbacks = handler == 'keydown' ? keydownCallbacks : keyupCallbacks;
-  // 0 is the smallest falsy value
-  [].concat(keys).map(key => (callbacks[key] = 0));
+  [].concat(keys).map(key => delete callbacks[key]);
 }
 
 /**

--- a/src/keyboard.js
+++ b/src/keyboard.js
@@ -51,10 +51,10 @@ export let keyMap = {
   Enter: 'enter',
   Escape: 'esc',
   Space: 'space',
-  ArrowLeft: 'left',
-  ArrowUp: 'up',
-  ArrowRight: 'right',
-  ArrowDown: 'down'
+  ArrowLeft: 'arrowleft',
+  ArrowUp: 'arrowup',
+  ArrowRight: 'arrowright',
+  ArrowDown: 'arrowdown'
 };
 
 /**
@@ -110,8 +110,8 @@ export function initKeys() {
   // alpha keys
   // @see https://stackoverflow.com/a/43095772/2124254
   for (i = 0; i < 26; i++) {
-    // rollupjs considers this a side-effect (for now), so we'll do it in the
-    // initKeys function
+    // rollupjs considers this a side-effect (for now), so we'll do it
+    // in the initKeys function
     keyMap[i + 65] = keyMap['Key' + String.fromCharCode(i + 65)] = String.fromCharCode(i + 97);
   }
 

--- a/src/kontra.defaults.js
+++ b/src/kontra.defaults.js
@@ -43,6 +43,7 @@ import {
   collides,
   getWorldRect
 } from './helpers.js';
+import { initInput, onInput, offInput } from './input.js';
 import { keyMap, initKeys, onKey, offKey, keyPressed } from './keyboard.js';
 import { registerPlugin, unregisterPlugin, extendObject } from './plugin.js';
 import {
@@ -124,6 +125,10 @@ let kontra = {
   getStoreItem,
   collides,
   getWorldRect,
+
+  initInput,
+  onInput,
+  offInput,
 
   keyMap,
   initKeys,

--- a/src/kontra.js
+++ b/src/kontra.js
@@ -43,6 +43,7 @@ export {
   collides,
   getWorldRect
 } from './helpers.js';
+export { initInput, onInput, offInput } from './input.js';
 export { keyMap, initKeys, onKey, offKey, keyPressed } from './keyboard.js';
 export { registerPlugin, unregisterPlugin, extendObject } from './plugin.js';
 export {

--- a/test/setup.js
+++ b/test/setup.js
@@ -17,5 +17,3 @@ afterEach(() => {
   document.querySelectorAll('canvas').forEach(canvas => canvas.remove());
   document.querySelectorAll('[data-kontra]').forEach(node => node.remove());
 });
-
-setup();

--- a/test/typings/input.ts
+++ b/test/typings/input.ts
@@ -1,0 +1,15 @@
+import * as kontra from '../../kontra.js';
+
+kontra.initInput();
+
+kontra.onInput('south', () => {
+  console.log('south gamepad pressed');
+});
+kontra.onInput(['arrowleft', 'south'], () => {});
+kontra.onInput('south', () => {}, { gamepad: { gamepad: 1 }});
+kontra.onInput('arrowleft', () => {}, { key: { handler: 'keydown' }});
+
+kontra.offInput('south');
+kontra.offInput(['south', 'arrowleft']);
+kontra.offInput('south', { gamepad: { gamepad: 1 }});
+kontra.offInput('arrowleft', { key: { handler: 'keydown' }});

--- a/test/unit/button.spec.js
+++ b/test/unit/button.spec.js
@@ -2,6 +2,7 @@ import Button, { ButtonClass } from '../../src/button.js';
 import Text, { TextClass } from '../../src/text.js';
 import { initPointer, resetPointers } from '../../src/pointer.js';
 import { srOnlyStyle } from '../../src/utils.js';
+import { simulateEvent } from '../utils.js';
 
 // --------------------------------------------------
 // button
@@ -165,48 +166,27 @@ describe('button', () => {
   // keyboard events
   // --------------------------------------------------
   describe('keyboard events', () => {
-    function simulateEvent(type, config) {
-      let evt;
-
-      // PhantomJS <2.0.0 throws an error for the `new Event` call, so we need to supply an
-      // alternative form of creating an event just for PhantomJS
-      // @see https://github.com/ariya/phantomjs/issues/11289#issuecomment-38880333
-      try {
-        evt = new Event(type);
-      } catch (e) {
-        evt = document.createEvent('Event');
-        evt.initEvent(type, true, false);
-      }
-
-      config = config || {};
-      for (let prop in config) {
-        evt[prop] = config[prop];
-      }
-
-      button._dn.dispatchEvent(evt);
-    }
-
     // --------------------------------------------------
     // onDown
     // --------------------------------------------------
     describe('onDown', () => {
       it('should call onDown if Enter is pressed', () => {
         sinon.spy(button, 'onDown');
-        simulateEvent('keydown', { code: 'Enter' });
+        simulateEvent('keydown', { code: 'Enter' }, button._dn);
 
         expect(button.onDown.called).to.be.true;
       });
 
       it('should call onDown if Space is pressed', () => {
         sinon.spy(button, 'onDown');
-        simulateEvent('keydown', { code: 'Space' });
+        simulateEvent('keydown', { code: 'Space' }, button._dn);
 
         expect(button.onDown.called).to.be.true;
       });
 
       it('should not call onDown if any other key is pressed', () => {
         sinon.spy(button, 'onDown');
-        simulateEvent('keydown', { code: 'KeyA' });
+        simulateEvent('keydown', { code: 'KeyA' }, button._dn);
 
         expect(button.onDown.called).to.be.false;
       });
@@ -218,21 +198,21 @@ describe('button', () => {
     describe('onUp', () => {
       it('should call onUp if Enter is pressed', () => {
         sinon.spy(button, 'onUp');
-        simulateEvent('keyup', { code: 'Enter' });
+        simulateEvent('keyup', { code: 'Enter' }, button._dn);
 
         expect(button.onUp.called).to.be.true;
       });
 
       it('should call onUp if Space is pressed', () => {
         sinon.spy(button, 'onUp');
-        simulateEvent('keyup', { code: 'Space' });
+        simulateEvent('keyup', { code: 'Space' }, button._dn);
 
         expect(button.onUp.called).to.be.true;
       });
 
       it('should not call onUp if any other key is pressed', () => {
         sinon.spy(button, 'onUp');
-        simulateEvent('keyup', { code: 'KeyA' });
+        simulateEvent('keyup', { code: 'KeyA' }, button._dn);
 
         expect(button.onUp.called).to.be.false;
       });

--- a/test/unit/gameLoop.spec.js
+++ b/test/unit/gameLoop.spec.js
@@ -2,32 +2,13 @@ import GameLoop from '../../src/gameLoop.js';
 import { getContext } from '../../src/core.js';
 import { on } from '../../src/events.js';
 import { noop } from '../../src/utils.js';
+import { simulateEvent } from '../utils.js';
 
 // --------------------------------------------------
 // gameloop
 // --------------------------------------------------
 describe('gameLoop', () => {
   let loop;
-
-  /**
-   * Simulate an event.
-   * @param {string} type - Type of keyboard event.
-   */
-  function simulateEvent(type) {
-    let evt;
-
-    // PhantomJS <2.0.0 throws an error for the `new Event` call, so we need to supply an
-    // alternative form of creating an event just for PhantomJS
-    // @see https://github.com/ariya/phantomjs/issues/11289#issuecomment-38880333
-    try {
-      evt = new Event(type);
-    } catch (e) {
-      evt = document.createEvent('Event');
-      evt.initEvent(type, true, false);
-    }
-
-    window.dispatchEvent(evt);
-  }
 
   afterEach(() => {
     loop && loop.stop();

--- a/test/unit/gamepad.spec.js
+++ b/test/unit/gamepad.spec.js
@@ -1,72 +1,13 @@
 import * as gamepad from '../../src/gamepad.js';
 import { callbacks as eventCallbacks } from '../../src/events.js';
+import { simulateEvent, simulateGamepadEvent, getGamepadsStub, createGamepad } from '../utils.js';
 
 // --------------------------------------------------
 // gamepad
 // --------------------------------------------------
 describe('gamepad', () => {
-  /**
-   * Simulate an event.
-   * @param {string} type - Type of event.
-   * @param {object} [config] - Additional settings for the event.
-   */
-  function simulateEvent(type, config, async = false) {
-    let evt = new Event(type);
-
-    config = config || {};
-    for (let prop in config) {
-      evt[prop] = config[prop];
-    }
-
-    window.dispatchEvent(evt);
-
-    return evt;
-  }
-
-  /**
-   * Simulate a gamepad event.
-   * @param {string} type - Type of gamepad event.
-   * @param {object} gamepad - Gamepad object.
-   * @param {number} gamepad.index - Index of the gamepad
-   * @param {Object[]} [gamepad.buttons] - GamepadButtons and their state
-   * @param {Number[]} [gamepad.axes] - Gamepad axes values
-   *
-   */
-  function simulateGamepadEvent(type, gamepad) {
-    let evt = new GamepadEvent(type);
-
-    // evt.gamepad is read-only so we need to override it
-    Object.defineProperty(evt, 'gamepad', {
-      value: {
-        buttons: [],
-        axes: [],
-        ...gamepad
-      }
-    });
-
-    window.dispatchEvent(evt);
-
-    return evt;
-  }
-
   // simulate gamepad object
-  let getGamepadsStub = [];
   let gamepadStub;
-
-  function createGamepad(index = getGamepadsStub.length) {
-    let gamepadObj = {
-      index,
-      connected: true,
-      buttons: [],
-      axes: [0, 0, 0, 0]
-    };
-    for (let i = 0; i < 16; i++) {
-      gamepadObj.buttons[i] = { pressed: false };
-    }
-
-    simulateGamepadEvent('gamepadconnected', gamepadObj);
-    getGamepadsStub[index] = gamepadObj;
-  }
 
   before(() => {
     gamepadStub = sinon.stub(navigator, 'getGamepads').returns(getGamepadsStub);

--- a/test/unit/input.spec.js
+++ b/test/unit/input.spec.js
@@ -193,6 +193,14 @@ describe('input', () => {
 
       expect(spy.called).to.be.true;
     });
+
+    it('should throw error if input name is invalid', () => {
+      function fn() {
+        input.onInput('foo', () => {});
+      }
+
+      expect(fn).to.throw();
+    });
   });
 
   // --------------------------------------------------

--- a/test/unit/input.spec.js
+++ b/test/unit/input.spec.js
@@ -1,0 +1,33 @@
+import * as input from '../../src/input.js';
+import { getPointer } from '../../src/pointer.js';
+
+// --------------------------------------------------
+// input
+// --------------------------------------------------
+describe('input', () => {
+  it('should export api', () => {
+    expect(input.initInput).to.be.an('function');
+    expect(input.onInput).to.be.an('function');
+    expect(input.offInput).to.be.an('function');
+  });
+
+  // --------------------------------------------------
+  // initInput
+  // --------------------------------------------------
+  it('should init inputs', () => {
+    input.initInput();
+  });
+
+  it('should pass pointer options', () => {
+    input.initInput({
+      pointer: { radius: 10 }
+    });
+
+    expect(getPointer().radius).to.equal(10);
+  });
+
+  // --------------------------------------------------
+  // onInput
+  // --------------------------------------------------
+  it('should call the callback when key is pressed', () => {});
+});

--- a/test/unit/input.spec.js
+++ b/test/unit/input.spec.js
@@ -1,33 +1,307 @@
 import * as input from '../../src/input.js';
-import { getPointer } from '../../src/pointer.js';
+import { getCanvas } from '../../src/core.js';
+import { emit, callbacks as eventCallbacks } from '../../src/events.js';
+import { keyMap } from '../../src/keyboard.js';
+import { gamepadMap, updateGamepad } from '../../src/gamepad.js';
+import { gestureMap } from '../../src/gesture.js';
+import { getPointer, resetPointers } from '../../src/pointer.js';
+import { simulateEvent, simulateGamepadEvent, createGamepad, getGamepadsStub } from '../utils.js';
 
 // --------------------------------------------------
 // input
 // --------------------------------------------------
 describe('input', () => {
+  let gamepadStub;
+
+  before(() => {
+    gamepadStub = sinon.stub(navigator, 'getGamepads').returns(getGamepadsStub);
+  });
+
+  beforeEach(() => {
+    input.initInput();
+  });
+
+  afterEach(() => {
+    resetPointers();
+  });
+
+  after(() => {
+    gamepadStub.restore();
+  });
+
   it('should export api', () => {
     expect(input.initInput).to.be.an('function');
     expect(input.onInput).to.be.an('function');
     expect(input.offInput).to.be.an('function');
   });
 
+  it('should have unique input names for each input type', () => {
+    // if keyboard, gamepad, gesture, or pointer share an input name
+    // it will cause problems
+    let inputNames = [
+      // keyboard can have non-unique keys
+      ...Object.values(keyMap).filter((name, index, array) => {
+        return array.indexOf(name) === index;
+      }),
+      ...Object.values(gamepadMap),
+      ...Object.keys(gestureMap),
+      ...['down', 'up']
+    ];
+
+    let isUnique = inputNames.every((name, index) => {
+      return inputNames.indexOf(name) === index;
+    });
+    expect(isUnique).to.be.true;
+  });
+
   // --------------------------------------------------
   // initInput
   // --------------------------------------------------
-  it('should init inputs', () => {
-    input.initInput();
-  });
+  describe('initInput', () => {
+    it('should init inputs', () => {
+      let windowSpy = sinon.spy(window, 'addEventListener');
+      let canvasSpy = sinon.spy(getCanvas(), 'addEventListener');
 
-  it('should pass pointer options', () => {
-    input.initInput({
-      pointer: { radius: 10 }
+      input.initInput();
+
+      // keyboard
+      expect(windowSpy.calledWith('keydown')).to.be.true;
+      // gamepad
+      expect(windowSpy.calledWith('gamepadconnected')).to.be.true;
+      // gesture
+      expect(eventCallbacks.touchChanged).to.exist;
+      // pointer
+      expect(canvasSpy.calledWith('mousedown')).to.be.true;
+
+      windowSpy.restore();
+      canvasSpy.restore();
     });
 
-    expect(getPointer().radius).to.equal(10);
+    it('should pass pointer options', () => {
+      resetPointers();
+      input.initInput({
+        pointer: { radius: 10 }
+      });
+
+      expect(getPointer().radius).to.equal(10);
+    });
+
+    it('should return init objects', () => {
+      let object = input.initInput();
+
+      expect(object.pointer).to.exist;
+    });
   });
 
   // --------------------------------------------------
   // onInput
   // --------------------------------------------------
-  it('should call the callback when key is pressed', () => {});
+  describe('onInput', () => {
+    it('should call the callback for keyboard event', () => {
+      let spy = sinon.spy();
+      input.onInput('arrowleft', spy);
+
+      simulateEvent('keydown', { code: 'ArrowLeft' });
+
+      expect(spy.called).to.be.true;
+    });
+
+    it('should call the callback for gamepad event', () => {
+      let spy = sinon.spy();
+      input.onInput('south', spy);
+
+      createGamepad();
+      getGamepadsStub[0].buttons[0].pressed = true;
+      updateGamepad();
+
+      expect(spy.called).to.be.true;
+    });
+
+    it('should call the callback for gesture event', () => {
+      let spy = sinon.spy();
+      input.onInput('swipeleft', spy);
+
+      let evt = { type: 'touchend' };
+      let touches = {
+        length: 1,
+        0: {
+          start: {
+            x: 50,
+            y: 50
+          },
+          x: 30,
+          y: 50
+        }
+      };
+
+      emit('touchChanged', evt, touches);
+
+      expect(spy.called).to.be.true;
+    });
+
+    it('should call the callback for pointer event', () => {
+      let spy = sinon.spy();
+      input.onInput('down', spy);
+
+      simulateEvent(
+        'mousedown',
+        {
+          identifier: 0,
+          clientX: 1000,
+          clientY: 50
+        },
+        getCanvas()
+      );
+
+      expect(spy.called).to.be.true;
+    });
+
+    it('should accept an array of inputs', () => {
+      let spy = sinon.spy();
+      input.onInput(['dpadleft', 'arrowleft', 'swipeleft'], spy);
+
+      simulateEvent('keydown', { code: 'ArrowLeft' });
+
+      expect(spy.called).to.be.true;
+    });
+
+    it('should pass keyboard options', () => {
+      let spy = sinon.spy();
+      input.onInput('arrowleft', spy, {
+        key: { handler: 'keyup' }
+      });
+
+      simulateEvent('keyup', { code: 'ArrowLeft' });
+
+      expect(spy.called).to.be.true;
+    });
+
+    it('should pass gamepad options', () => {
+      let spy = sinon.spy();
+      input.onInput('south', spy, {
+        gamepad: { handler: 'gamepadup' }
+      });
+
+      createGamepad();
+      getGamepadsStub[0].buttons[0].pressed = true;
+      updateGamepad();
+
+      expect(spy.called).to.be.false;
+
+      getGamepadsStub[0].buttons[0].pressed = false;
+      updateGamepad();
+
+      expect(spy.called).to.be.true;
+    });
+  });
+
+  // --------------------------------------------------
+  // offInput
+  // --------------------------------------------------
+  describe('offInput', () => {
+    it('should not call the callback for keyboard event', () => {
+      let spy = sinon.spy();
+      input.onInput('arrowleft', spy);
+      input.offInput('arrowleft');
+
+      simulateEvent('keydown', { code: 'ArrowLeft' });
+
+      expect(spy.called).to.be.false;
+    });
+
+    it('should not call the callback for gamepad event', () => {
+      let spy = sinon.spy();
+      input.onInput('south', spy);
+      input.offInput('south');
+
+      createGamepad();
+      getGamepadsStub[0].buttons[0].pressed = true;
+      updateGamepad();
+
+      expect(spy.called).to.be.false;
+    });
+
+    it('should not call the callback for gesture event', () => {
+      let spy = sinon.spy();
+      input.onInput('swipeleft', spy);
+      input.offInput('swipeleft');
+
+      let evt = { type: 'touchend' };
+      let touches = {
+        length: 1,
+        0: {
+          start: {
+            x: 50,
+            y: 50
+          },
+          x: 30,
+          y: 50
+        }
+      };
+
+      emit('touchChanged', evt, touches);
+
+      expect(spy.called).to.be.false;
+    });
+
+    it('should not call the callback for pointer event', () => {
+      let spy = sinon.spy();
+      input.onInput('down', spy);
+      input.offInput('down');
+
+      simulateEvent(
+        'mousedown',
+        {
+          identifier: 0,
+          clientX: 1000,
+          clientY: 50
+        },
+        getCanvas()
+      );
+
+      expect(spy.called).to.be.false;
+    });
+
+    it('should accept an array of inputs', () => {
+      let spy = sinon.spy();
+      input.onInput(['dpadleft', 'arrowleft', 'swipeleft'], spy);
+      input.offInput(['dpadleft', 'arrowleft']);
+
+      simulateEvent('keydown', { code: 'ArrowLeft' });
+
+      expect(spy.called).to.be.false;
+    });
+
+    it('should pass keyboard options', () => {
+      let spy = sinon.spy();
+      input.onInput('arrowleft', spy, {
+        key: { handler: 'keyup' }
+      });
+      input.offInput('arrowleft', {
+        key: { handler: 'keyup' }
+      });
+
+      simulateEvent('keyup', { code: 'ArrowLeft' });
+
+      expect(spy.called).to.be.false;
+    });
+
+    it('should pass gamepad options', () => {
+      let spy = sinon.spy();
+      input.onInput('south', spy, {
+        gamepad: { handler: 'gamepadup' }
+      });
+      input.offInput('south', {
+        gamepad: { handler: 'gamepadup' }
+      });
+
+      createGamepad();
+      getGamepadsStub[0].buttons[0].pressed = true;
+      updateGamepad();
+      getGamepadsStub[0].buttons[0].pressed = false;
+      updateGamepad();
+
+      expect(spy.called).to.be.false;
+    });
+  });
 });

--- a/test/unit/keyboard.spec.js
+++ b/test/unit/keyboard.spec.js
@@ -1,49 +1,10 @@
 import * as keyboard from '../../src/keyboard.js';
+import { simulateEvent } from '../utils.js';
 
 // --------------------------------------------------
 // keyboard
 // --------------------------------------------------
 describe('keyboard', () => {
-  /**
-   * Simulate a keyboard event.
-   * @param {string} type - Type of keyboard event.
-   * @param {object} [config] - Additional settings for the event.
-   * @param {boolean} [config.ctrlKey=false]
-   * @param {boolean} [config.shiftKey=false]
-   * @param {boolean} [config.altKey=false]
-   * @param {boolean} [config.metaKey=false]
-   * @param {boolean} [config.keyCode=0]
-   * @param {boolean} [async=false] - If the event should fire async.
-   */
-  function simulateEvent(type, config, async = false) {
-    let evt;
-
-    // PhantomJS <2.0.0 throws an error for the `new Event` call, so we need to supply an
-    // alternative form of creating an event just for PhantomJS
-    // @see https://github.com/ariya/phantomjs/issues/11289#issuecomment-38880333
-    try {
-      evt = new Event(type);
-    } catch (e) {
-      evt = document.createEvent('Event');
-      evt.initEvent(type, true, false);
-    }
-
-    config = config || {};
-    for (let prop in config) {
-      evt[prop] = config[prop];
-    }
-
-    if (async) {
-      setTimeout(() => {
-        window.dispatchEvent(evt);
-      }, 100);
-    } else {
-      window.dispatchEvent(evt);
-    }
-
-    return evt;
-  }
-
   // reset pressed keys before each test
   beforeEach(() => {
     simulateEvent('blur');
@@ -97,9 +58,9 @@ describe('keyboard', () => {
   });
 
   // --------------------------------------------------
-  // bind
+  // onKey
   // --------------------------------------------------
-  describe('bind', () => {
+  describe('onKey', () => {
     // Defaults to keydown
     describe('handler=keydown', () => {
       it('should call the callback when a single key combination is pressed', done => {
@@ -110,7 +71,7 @@ describe('keyboard', () => {
         simulateEvent('keydown', { code: 'KeyA' });
       });
 
-      it('should accept an array of key combinations to bind', done => {
+      it('should accept an array of key combinations to register', done => {
         keyboard.onKey(['a', 'b'], evt => {
           done();
         });
@@ -134,7 +95,7 @@ describe('keyboard', () => {
         simulateEvent('keyup', { code: 'KeyA' });
       });
 
-      it('should accept an array of key combinations to bind', done => {
+      it('should accept an array of key combinations to register', done => {
         keyboard.onKey(
           ['a', 'b'],
           evt => {
@@ -157,7 +118,7 @@ describe('keyboard', () => {
           done();
         });
 
-        let event = simulateEvent('keydown', { code: 'KeyA' }, true);
+        let event = simulateEvent('keydown', { code: 'KeyA', async: true });
         spy = sinon.spy(event, 'preventDefault');
       });
     });
@@ -179,14 +140,14 @@ describe('keyboard', () => {
   });
 
   // --------------------------------------------------
-  // unbind
+  // offKey
   // --------------------------------------------------
-  describe('unbind', () => {
+  describe('offKey', () => {
     // Defaults to keydown
     describe('handler=keydown', () => {
-      it('should not call the callback when the combination has been unbound', () => {
+      it('should not call the callback when the combination has been unregistered', () => {
         keyboard.onKey('a', () => {
-          // this should never be called since the key combination was unbound
+          // this should never be called since the key combination was unregistered
           expect(false).to.be.true;
         });
 
@@ -195,9 +156,9 @@ describe('keyboard', () => {
         simulateEvent('keydown', { which: 65 });
       });
 
-      it('should accept an array of key combinations to unbind', () => {
+      it('should accept an array of key combinations to unregister', () => {
         keyboard.onKey(['a', 'b'], () => {
-          // this should never be called since the key combination was unbound
+          // this should never be called since the key combination was unregistered
           expect(false).to.be.true;
         });
 
@@ -211,11 +172,11 @@ describe('keyboard', () => {
     describe('handler=keyup', () => {
       const handler = 'keyup';
 
-      it('should not call the callback when the combination has been unbound', () => {
+      it('should not call the callback when the combination has been unregistered', () => {
         keyboard.onKey(
           'a',
           () => {
-            // this should never be called since the key combination was unbound
+            // this should never be called since the key combination was unregistered
             expect(false).to.be.true;
           },
           handler
@@ -226,11 +187,11 @@ describe('keyboard', () => {
         simulateEvent('keyup', { which: 65 });
       });
 
-      it('should accept an array of key combinations to unbind', () => {
+      it('should accept an array of key combinations to unregister', () => {
         keyboard.onKey(
           ['a', 'b'],
           () => {
-            // this should never be called since the key combination was unbound
+            // this should never be called since the key combination was unregistered
             expect(false).to.be.true;
           },
           handler

--- a/test/unit/pointer.spec.js
+++ b/test/unit/pointer.spec.js
@@ -2,6 +2,7 @@ import * as pointer from '../../src/pointer.js';
 import { getCanvas } from '../../src/core.js';
 import { emit, on } from '../../src/events.js';
 import { noop } from '../../src/utils.js';
+import { simulateEvent } from '../utils.js';
 
 // --------------------------------------------------
 // pointer
@@ -9,33 +10,6 @@ import { noop } from '../../src/utils.js';
 describe('pointer', () => {
   let object;
   let canvas;
-
-  /**
-   * Simulate a mouse event.
-   * @param {string} type - Type of mouse event.
-   * @param {object} [config] - Additional settings for the event.
-   * @param {number} [config.button]
-   */
-  function simulateEvent(type, config, elm) {
-    let event;
-
-    // PhantomJS <2.0.0 throws an error for the `new Event` call, so we need to supply an
-    // alternative form of creating an event just for PhantomJS
-    // @see https://github.com/ariya/phantomjs/issues/11289#issuecomment-38880333
-    try {
-      event = new Event(type, { bubbles: true });
-    } catch (e) {
-      event = document.createEvent('Event');
-      event.initEvent(type, true, false);
-    }
-
-    config = config || {};
-    for (let prop in config) {
-      event[prop] = config[prop];
-    }
-
-    (elm || canvas).dispatchEvent(event);
-  }
 
   // reset pressed buttons before each test
   beforeEach(() => {
@@ -48,7 +22,7 @@ describe('pointer', () => {
 
     pointer.initPointer();
 
-    simulateEvent('blur');
+    simulateEvent('blur', {}, canvas);
 
     object = {
       x: 100,
@@ -127,36 +101,48 @@ describe('pointer', () => {
     });
 
     it('should return true for a button', () => {
-      simulateEvent('mousedown', { button: 1 });
+      simulateEvent('mousedown', { button: 1 }, canvas);
 
       expect(pointer.pointerPressed('middle')).to.be.true;
     });
 
     it('should return false if the button is no longer pressed', () => {
-      simulateEvent('mousedown', { button: 2 });
-      simulateEvent('mouseup', { button: 2 });
+      simulateEvent('mousedown', { button: 2 }, canvas);
+      simulateEvent('mouseup', { button: 2 }, canvas);
 
       expect(pointer.pointerPressed('right')).to.be.false;
     });
 
     it('should return true for touchstart', () => {
-      simulateEvent('touchstart', {
-        touches: [{ identifier: 0, clientX: 100, clientY: 50 }],
-        changedTouches: [{ identifier: 0, clientX: 100, clientY: 50 }]
-      });
+      simulateEvent(
+        'touchstart',
+        {
+          touches: [{ identifier: 0, clientX: 100, clientY: 50 }],
+          changedTouches: [{ identifier: 0, clientX: 100, clientY: 50 }]
+        },
+        canvas
+      );
 
       expect(pointer.pointerPressed('left')).to.be.true;
     });
 
     it('should return false for a touchend', () => {
-      simulateEvent('touchstart', {
-        touches: [{ identifier: 0, clientX: 100, clientY: 50 }],
-        changedTouches: [{ identifier: 0, clientX: 100, clientY: 50 }]
-      });
-      simulateEvent('touchend', {
-        touches: [{ identifier: 0, clientX: 100, clientY: 50 }],
-        changedTouches: [{ identifier: 0, clientX: 100, clientY: 50 }]
-      });
+      simulateEvent(
+        'touchstart',
+        {
+          touches: [{ identifier: 0, clientX: 100, clientY: 50 }],
+          changedTouches: [{ identifier: 0, clientX: 100, clientY: 50 }]
+        },
+        canvas
+      );
+      simulateEvent(
+        'touchend',
+        {
+          touches: [{ identifier: 0, clientX: 100, clientY: 50 }],
+          changedTouches: [{ identifier: 0, clientX: 100, clientY: 50 }]
+        },
+        canvas
+      );
 
       expect(pointer.pointerPressed('left')).to.be.false;
     });
@@ -460,7 +446,7 @@ describe('pointer', () => {
     describe('mousemove', () => {
       it('should update the x and y pointer coordinates', () => {
         pntr.x = pntr.y = 0;
-        simulateEvent('mousemove', { identifier: 0, clientX: 100, clientY: 50 });
+        simulateEvent('mousemove', { identifier: 0, clientX: 100, clientY: 50 }, canvas);
 
         expect(pntr.x).to.equal(100);
         expect(pntr.y).to.equal(50);
@@ -474,7 +460,7 @@ describe('pointer', () => {
         canvas.style.padding = '32px';
         pntr = pointer.initPointer({ canvas });
 
-        simulateEvent('mousemove', { identifier: 0, clientX: 100, clientY: 50 });
+        simulateEvent('mousemove', { identifier: 0, clientX: 100, clientY: 50 }, canvas);
 
         expect(pntr.x).to.equal(36);
         expect(pntr.y).to.equal(-14);
@@ -488,7 +474,7 @@ describe('pointer', () => {
         canvas.style.transformOrigin = 'top left';
         pntr = pointer.initPointer({ canvas });
 
-        simulateEvent('mousemove', { identifier: 0, clientX: 50, clientY: 25 });
+        simulateEvent('mousemove', { identifier: 0, clientX: 50, clientY: 25 }, canvas);
 
         expect(pntr.x).to.equal(100);
         expect(pntr.y).to.equal(50);
@@ -501,7 +487,7 @@ describe('pointer', () => {
         canvas.style.width = canvas.width * 2 + 'px';
         pntr = pointer.initPointer({ canvas });
 
-        simulateEvent('mousemove', { identifier: 0, clientX: 100, clientY: 50 });
+        simulateEvent('mousemove', { identifier: 0, clientX: 100, clientY: 50 }, canvas);
 
         expect(pntr.x).to.equal(50);
         expect(pntr.y).to.equal(25);
@@ -518,7 +504,7 @@ describe('pointer', () => {
         canvas.style.width = canvas.width * 2 + 'px';
         pntr = pointer.initPointer({ canvas });
 
-        simulateEvent('mousemove', { identifier: 0, clientX: 100, clientY: 50 });
+        simulateEvent('mousemove', { identifier: 0, clientX: 100, clientY: 50 }, canvas);
 
         expect(pntr.x).to.equal(68);
         expect(pntr.y).to.equal(18);
@@ -526,15 +512,15 @@ describe('pointer', () => {
 
       it('should call the objects onOver function if it is the target', () => {
         object.onOver = sinon.spy();
-        simulateEvent('mousemove', { identifier: 0, clientX: 105, clientY: 55 });
+        simulateEvent('mousemove', { identifier: 0, clientX: 105, clientY: 55 }, canvas);
 
         expect(object.onOver.called).to.be.true;
       });
 
       it('should call the objects onOut function if it is no longer the target', () => {
         object.onOut = sinon.spy();
-        simulateEvent('mousemove', { identifier: 0, clientX: 105, clientY: 55 });
-        simulateEvent('mousemove', { identifier: 0, clientX: 150, clientY: 55 });
+        simulateEvent('mousemove', { identifier: 0, clientX: 105, clientY: 55 }, canvas);
+        simulateEvent('mousemove', { identifier: 0, clientX: 150, clientY: 55 }, canvas);
 
         expect(object.onOut.called).to.be.true;
       });
@@ -553,8 +539,8 @@ describe('pointer', () => {
         emit('tick');
 
         object.onOut = sinon.spy();
-        simulateEvent('mousemove', { identifier: 0, clientX: 105, clientY: 55 });
-        simulateEvent('mousemove', { identifier: 0, clientX: 155, clientY: 55 });
+        simulateEvent('mousemove', { identifier: 0, clientX: 105, clientY: 55 }, canvas);
+        simulateEvent('mousemove', { identifier: 0, clientX: 155, clientY: 55 }, canvas);
 
         expect(pointer.pointerOver(obj)).to.be.true;
         expect(object.onOut.called).to.be.true;
@@ -566,24 +552,24 @@ describe('pointer', () => {
           y: 0.5
         };
         object.onOver = sinon.spy();
-        simulateEvent('mousemove', { identifier: 0, clientX: 110, clientY: 55 });
+        simulateEvent('mousemove', { identifier: 0, clientX: 110, clientY: 55 }, canvas);
 
         expect(object.onOver.called).to.not.be.true;
 
-        simulateEvent('mousemove', { identifier: 0, clientX: 95, clientY: 55 });
+        simulateEvent('mousemove', { identifier: 0, clientX: 95, clientY: 55 }, canvas);
 
         expect(object.onOver.called).to.be.true;
       });
 
       it('should handle objects from different canvas', () => {
-        let canvas = document.createElement('canvas');
-        document.body.appendChild(canvas);
-        canvas.width = canvas.height = 600;
-        canvas.style.position = 'fixed';
-        canvas.style.top = 0;
-        canvas.style.left = 0;
+        let otherCanvas = document.createElement('canvas');
+        document.body.appendChild(otherCanvas);
+        otherCanvas.width = otherCanvas.height = 600;
+        otherCanvas.style.position = 'fixed';
+        otherCanvas.style.top = 0;
+        otherCanvas.style.left = 0;
 
-        pointer.initPointer({ canvas });
+        pointer.initPointer({ canvas: otherCanvas });
 
         let obj = {
           x: 100,
@@ -592,14 +578,14 @@ describe('pointer', () => {
           height: 20,
           render: noop,
           onOver: sinon.spy(),
-          context: { canvas }
+          context: { canvas: otherCanvas }
         };
         pointer.track(obj);
         obj.render();
         emit('tick');
 
         // wrong canvas
-        simulateEvent('mousemove', { identifier: 0, clientX: 105, clientY: 55 });
+        simulateEvent('mousemove', { identifier: 0, clientX: 105, clientY: 55 }, otherCanvas);
         expect(obj.onOver.called).to.false;
 
         simulateEvent('mousemove', { identifier: 0, clientX: 105, clientY: 55 }, canvas);
@@ -624,7 +610,7 @@ describe('pointer', () => {
           pntr.x = pntr.y = 0;
           event.clientX = 100;
           event.clientY = 50;
-          simulateEvent(eventName, config);
+          simulateEvent(eventName, config, canvas);
 
           expect(pntr.x).to.equal(100);
           expect(pntr.y).to.equal(50);
@@ -640,7 +626,7 @@ describe('pointer', () => {
 
           event.clientX = 100;
           event.clientY = 50;
-          simulateEvent(eventName, config);
+          simulateEvent(eventName, config, canvas);
 
           expect(pntr.x).to.equal(36);
           expect(pntr.y).to.equal(-14);
@@ -656,7 +642,7 @@ describe('pointer', () => {
 
           event.clientX = 50;
           event.clientY = 25;
-          simulateEvent(eventName, config);
+          simulateEvent(eventName, config, canvas);
 
           expect(pntr.x).to.equal(100);
           expect(pntr.y).to.equal(50);
@@ -671,7 +657,7 @@ describe('pointer', () => {
 
           event.clientX = 100;
           event.clientY = 50;
-          simulateEvent(eventName, config);
+          simulateEvent(eventName, config, canvas);
 
           expect(pntr.x).to.equal(50);
           expect(pntr.y).to.equal(25);
@@ -690,7 +676,7 @@ describe('pointer', () => {
 
           event.clientX = 100;
           event.clientY = 50;
-          simulateEvent(eventName, config);
+          simulateEvent(eventName, config, canvas);
 
           expect(pntr.x).to.equal(68);
           expect(pntr.y).to.equal(18);
@@ -701,7 +687,7 @@ describe('pointer', () => {
           pointer.onPointer(pointerHandler, spy);
           event.clientX = 100;
           event.clientY = 50;
-          simulateEvent(eventName, config);
+          simulateEvent(eventName, config, canvas);
 
           expect(spy.called).to.be.true;
         });
@@ -712,7 +698,7 @@ describe('pointer', () => {
           pointer.offPointer(pointerHandler);
           event.clientX = 100;
           event.clientY = 50;
-          simulateEvent(eventName, config);
+          simulateEvent(eventName, config, canvas);
 
           expect(spy.called).to.be.false;
         });
@@ -721,7 +707,7 @@ describe('pointer', () => {
           object[eventHandler] = sinon.spy();
           event.clientX = 105;
           event.clientY = 55;
-          simulateEvent(eventName, config);
+          simulateEvent(eventName, config, canvas);
 
           expect(object[eventHandler].called).to.be.true;
         });
@@ -734,26 +720,26 @@ describe('pointer', () => {
           object[eventHandler] = sinon.spy();
           event.clientX = 110;
           event.clientY = 55;
-          simulateEvent(eventName, config);
+          simulateEvent(eventName, config, canvas);
 
           expect(object[eventHandler].called).to.not.be.true;
 
           event.clientX = 95;
           event.clientY = 55;
-          simulateEvent(eventName, config);
+          simulateEvent(eventName, config, canvas);
 
           expect(object[eventHandler].called).to.be.true;
         });
 
         it('should handle objects from different canvas', () => {
-          let canvas = document.createElement('canvas');
-          document.body.appendChild(canvas);
-          canvas.width = canvas.height = 600;
-          canvas.style.position = 'fixed';
-          canvas.style.top = 0;
-          canvas.style.left = 0;
+          let otherCanvas = document.createElement('canvas');
+          document.body.appendChild(otherCanvas);
+          otherCanvas.width = otherCanvas.height = 600;
+          otherCanvas.style.position = 'fixed';
+          otherCanvas.style.top = 0;
+          otherCanvas.style.left = 0;
 
-          pointer.initPointer({ canvas });
+          pointer.initPointer({ canvas: otherCanvas });
 
           let obj = {
             x: 100,
@@ -762,7 +748,7 @@ describe('pointer', () => {
             height: 20,
             render: noop,
             [eventHandler]: sinon.spy(),
-            context: { canvas }
+            context: { canvas: otherCanvas }
           };
           pointer.track(obj);
           obj.render();
@@ -771,7 +757,7 @@ describe('pointer', () => {
           // wrong canvas
           event.clientX = 105;
           event.clientY = 55;
-          simulateEvent(eventName, config);
+          simulateEvent(eventName, config, otherCanvas);
           expect(obj[eventHandler].called).to.false;
 
           simulateEvent(eventName, config, canvas);
@@ -783,7 +769,7 @@ describe('pointer', () => {
             pntr.x = pntr.y = 0;
             event.clientX = 100;
             event.clientY = 50;
-            simulateEvent(eventName, config);
+            simulateEvent(eventName, config, canvas);
 
             expect(pntr.touches.length).to.equal(1);
             expect(pntr.touches[0]).to.deep.equal({
@@ -801,7 +787,7 @@ describe('pointer', () => {
             pntr.x = pntr.y = 0;
             event.clientX = 100;
             event.clientY = 50;
-            simulateEvent(eventName, config);
+            simulateEvent(eventName, config, canvas);
 
             let touch = {
               identifier: 1,
@@ -810,12 +796,16 @@ describe('pointer', () => {
             };
             event.clientX = 30;
             event.clientY = 40;
-            simulateEvent(eventName, {
-              // don't modify the original config
-              ...config,
-              touches: config.touches.concat(touch),
-              changedTouches: config.changedTouches.concat(touch)
-            });
+            simulateEvent(
+              eventName,
+              {
+                // don't modify the original config
+                ...config,
+                touches: config.touches.concat(touch),
+                changedTouches: config.changedTouches.concat(touch)
+              },
+              canvas
+            );
 
             expect(pntr.touches.length).to.equal(2);
             expect(pntr.touches[0]).to.deep.equal({
@@ -841,7 +831,7 @@ describe('pointer', () => {
           it('should emit touchChanged', () => {
             let spy = sinon.spy();
             on('touchChanged', spy);
-            simulateEvent(eventName, config);
+            simulateEvent(eventName, config, canvas);
             expect(spy.calledWith(sinon.match.instanceOf(Event), pntr.touches)).to.be.true;
           });
 
@@ -854,11 +844,15 @@ describe('pointer', () => {
               clientX: 10,
               clientY: 20
             };
-            simulateEvent(eventName, {
-              ...config,
-              touches: config.touches.concat(touch),
-              changedTouches: config.changedTouches.concat(touch)
-            });
+            simulateEvent(
+              eventName,
+              {
+                ...config,
+                touches: config.touches.concat(touch),
+                changedTouches: config.changedTouches.concat(touch)
+              },
+              canvas
+            );
 
             expect(spy.calledTwice).to.be.true;
           });
@@ -866,11 +860,11 @@ describe('pointer', () => {
 
         if (eventName === 'touchend') {
           it('should remove the touch', () => {
-            simulateEvent('touchstart', config);
+            simulateEvent('touchstart', config, canvas);
             expect(pntr.touches.length).to.equal(1);
             expect(pntr.touches[0]).to.exist;
 
-            simulateEvent(eventName, config);
+            simulateEvent(eventName, config, canvas);
             expect(pntr.touches.length).to.equal(0);
             expect(pntr.touches[0]).to.not.exist;
           });
@@ -881,23 +875,31 @@ describe('pointer', () => {
               clientX: 10,
               clientY: 20
             };
-            simulateEvent('touchstart', {
-              ...config,
-              touches: config.touches.concat(touch),
-              changedTouches: config.changedTouches.concat(touch)
-            });
+            simulateEvent(
+              'touchstart',
+              {
+                ...config,
+                touches: config.touches.concat(touch),
+                changedTouches: config.changedTouches.concat(touch)
+              },
+              canvas
+            );
             expect(pntr.touches.length).to.equal(2);
 
-            simulateEvent(eventName, config);
+            simulateEvent(eventName, config, canvas);
             expect(pntr.touches.length).to.equal(1);
             expect(pntr.touches[0]).to.not.exist;
             expect(pntr.touches[1]).to.exist;
 
-            simulateEvent(eventName, {
-              ...config,
-              touches: [touch],
-              changedTouches: [touch]
-            });
+            simulateEvent(
+              eventName,
+              {
+                ...config,
+                touches: [touch],
+                changedTouches: [touch]
+              },
+              canvas
+            );
             expect(pntr.touches.length).to.equal(0);
           });
 
@@ -910,20 +912,28 @@ describe('pointer', () => {
               clientX: 10,
               clientY: 20
             };
-            simulateEvent('touchstart', {
-              ...config,
-              touches: config.touches.concat(touch),
-              changedTouches: config.changedTouches.concat(touch)
-            });
+            simulateEvent(
+              'touchstart',
+              {
+                ...config,
+                touches: config.touches.concat(touch),
+                changedTouches: config.changedTouches.concat(touch)
+              },
+              canvas
+            );
 
-            simulateEvent(eventName, config);
+            simulateEvent(eventName, config, canvas);
             expect(spy.called).to.be.false;
 
-            simulateEvent(eventName, {
-              ...config,
-              touches: [touch],
-              changedTouches: [touch]
-            });
+            simulateEvent(
+              eventName,
+              {
+                ...config,
+                touches: [touch],
+                changedTouches: [touch]
+              },
+              canvas
+            );
             expect(spy.called).to.be.true;
           });
         }

--- a/test/unit/pointer.spec.js
+++ b/test/unit/pointer.spec.js
@@ -585,10 +585,10 @@ describe('pointer', () => {
         emit('tick');
 
         // wrong canvas
-        simulateEvent('mousemove', { identifier: 0, clientX: 105, clientY: 55 }, otherCanvas);
+        simulateEvent('mousemove', { identifier: 0, clientX: 105, clientY: 55 }, canvas);
         expect(obj.onOver.called).to.false;
 
-        simulateEvent('mousemove', { identifier: 0, clientX: 105, clientY: 55 }, canvas);
+        simulateEvent('mousemove', { identifier: 0, clientX: 105, clientY: 55 }, otherCanvas);
         expect(obj.onOver.called).to.be.true;
       });
     });
@@ -757,10 +757,10 @@ describe('pointer', () => {
           // wrong canvas
           event.clientX = 105;
           event.clientY = 55;
-          simulateEvent(eventName, config, otherCanvas);
+          simulateEvent(eventName, config, canvas);
           expect(obj[eventHandler].called).to.false;
 
-          simulateEvent(eventName, config, canvas);
+          simulateEvent(eventName, config, otherCanvas);
           expect(obj[eventHandler].called).to.be.true;
         });
 

--- a/test/utils.js
+++ b/test/utils.js
@@ -1,0 +1,63 @@
+/**
+ * Simulate a keyboard event.
+ * @param {string} type - Type of keyboard event.
+ * @param {object} [config] - Additional settings for the event.
+ * @param {HTMLElement} [node=window] - Node to dispatch the event on.
+ */
+export function simulateEvent(type, config = {}, node = window) {
+  let evt = new Event(type);
+
+  for (let prop in config) {
+    evt[prop] = config[prop];
+  }
+
+  if (config.async) {
+    window.setTimeout(() => node.dispatchEvent(evt), 100);
+  } else {
+    node.dispatchEvent(evt);
+  }
+
+  return evt;
+}
+
+/**
+ * Simulate a gamepad event.
+ * @param {string} type - Type of gamepad event.
+ * @param {object} gamepad - Gamepad object.
+ * @param {number} gamepad.index - Index of the gamepad
+ * @param {Object[]} [gamepad.buttons] - GamepadButtons and their state
+ * @param {Number[]} [gamepad.axes] - Gamepad axes values
+ *
+ */
+export function simulateGamepadEvent(type, gamepad) {
+  let evt = new GamepadEvent(type);
+
+  // evt.gamepad is read-only so we need to override it
+  Object.defineProperty(evt, 'gamepad', {
+    value: {
+      buttons: [],
+      axes: [],
+      ...gamepad
+    }
+  });
+
+  window.dispatchEvent(evt);
+
+  return evt;
+}
+
+export let getGamepadsStub = [];
+export function createGamepad(index = getGamepadsStub.length) {
+  let gamepadObj = {
+    index,
+    connected: true,
+    buttons: [],
+    axes: [0, 0, 0, 0]
+  };
+  for (let i = 0; i < 16; i++) {
+    gamepadObj.buttons[i] = { pressed: false };
+  }
+
+  simulateGamepadEvent('gamepadconnected', gamepadObj);
+  getGamepadsStub[index] = gamepadObj;
+}


### PR DESCRIPTION
Closes #261

Also cleaned up duplicate `simulateEvent` code.

BREAKING CHANGE