### PR TITLE
feat(helpers.collides, gameObject): do not return null if object is rotated. remove filterObjects from gameObject.render. Scene no longer extends gameObject

### DIFF
--- a/src/gameObject.js
+++ b/src/gameObject.js
@@ -247,10 +247,8 @@ class GameObject extends Updatable {
    * Render the game object and all children. Calls the game objects [draw()](api/gameObject#draw) function.
    * @memberof GameObject
    * @function render
-   *
-   * @param {Function} [filterObjects] - [Array.prototype.filter()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/filter) function which is used to filter which children to render.
    */
-  render(filterObjects) {
+  render() {
     let context = this.context;
     context.save();
 
@@ -315,9 +313,6 @@ class GameObject extends Updatable {
     // @ifdef GAMEOBJECT_GROUP
     // perform all transforms on the parent before rendering the children
     let children = this.children;
-    if (filterObjects) {
-      children = children.filter(filterObjects);
-    }
     children.map(child => child.render && child.render());
     // @endif
 

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -256,10 +256,9 @@ export function getStoreItem(key) {
 }
 
 /**
- * Check if a two objects collide. Uses a simple [Axis-Aligned Bounding Box (AABB) collision check](https://developer.mozilla.org/en-US/docs/Games/Techniques/2D_collision_detection#Axis-Aligned_Bounding_Box). Takes into account the sprites [anchor](api/gameObject#anchor) and [scale](api/gameObject#scale).
+ * Check if two objects collide. Uses a simple [Axis-Aligned Bounding Box (AABB) collision check](https://developer.mozilla.org/en-US/docs/Games/Techniques/2D_collision_detection#Axis-Aligned_Bounding_Box). Takes into account the objects [anchor](api/gameObject#anchor) and [scale](api/gameObject#scale).
  *
  * **NOTE:** Does not take into account object rotation. If you need collision detection between rotated objects you will need to implement your own `collides()` function. I suggest looking at the Separate Axis Theorem.
- *
  *
  * ```js
  * import { Sprite, collides } from 'kontra';
@@ -289,11 +288,9 @@ export function getStoreItem(key) {
  * @param {{x: number, y: number, width: number, height: number}|{world: {x: number, y: number, width: number, height: number}}} obj1 - Object reference.
  * @param {{x: number, y: number, width: number, height: number}|{world: {x: number, y: number, width: number, height: number}}} obj2 - Object to check collision against.
  *
- * @returns {Boolean|null} `true` if the objects collide, `false` otherwise. Will return `null` if the either of the two objects are rotated.
+ * @returns {Boolean} `true` if the objects collide, `false` otherwise.
  */
 export function collides(obj1, obj2) {
-  if (obj1.rotation || obj2.rotation) return null;
-
   // @ifdef GAMEOBJECT_SCALE||GAMEOBJECT_ANCHOR
   // destructure results to obj1 and obj2
   [obj1, obj2] = [obj1, obj2].map(obj => getWorldRect(obj));

--- a/src/scene.js
+++ b/src/scene.js
@@ -46,7 +46,6 @@ function getAllNodes(object) {
  * ```
  *
  * @class Scene
- * @extends GameObject
  *
  * @param {Object} properties - Properties of the scene.
  * @param {String} properties.id - The id of the scene.
@@ -57,6 +56,8 @@ function getAllNodes(object) {
  * @param {Function} [properties.cullFunction] - The function used to filter objects to render. Defaults to [helpers.collides](api/helpers#collides).
  * @param {Function} [properties.onShow] - Function called when the scene is shown.
  * @param {Function} [properties.onHide] - Function called when the scene is hidden.
+ *
+ * @param {...*} properties.props - Any additional properties you need added to the scene.
  */
 class Scene {
   constructor({

--- a/src/scene.js
+++ b/src/scene.js
@@ -1,7 +1,14 @@
-import GameObject, { GameObjectClass } from './gameObject.js';
+import { getCanvas } from './core.js';
+import GameObject from './gameObject.js';
 import { srOnlyStyle, addToDom } from './utils.js';
 import { collides } from './helpers.js';
 
+/**
+ * Recursively get all childrens HTML nodes.
+ * @param {Object} object - Root object.
+ *
+ * @returns {Object[]} All nested children HTML nodes.
+ */
 function getAllNodes(object) {
   let nodes = [];
 
@@ -44,13 +51,15 @@ function getAllNodes(object) {
  * @param {Object} properties - Properties of the scene.
  * @param {String} properties.id - The id of the scene.
  * @param {String} [properties.name=properties.id] - The name of the scene. Used by screen readers to identify each scene. Use this property to give the scene a human friendly name.
+ * @param {{render: Function, update: Function, x: number, y: number}[]} [properties.children] - Children to add to the scene.
+ * @param {HTMLCanvasElement} [properties.canvas] - The canvas element used to determine the size of the camera. Defaults to [core.getCanvas()](api/core#getCanvas).
  * @param {Boolean} [properties.cullObjects=true] - If the scene should not render objects outside the camera bounds.
  * @param {Function} [properties.cullFunction] - The function used to filter objects to render. Defaults to [helpers.collides](api/helpers#collides).
  * @param {Function} [properties.onShow] - Function called when the scene is shown.
  * @param {Function} [properties.onHide] - Function called when the scene is hidden.
  */
-class Scene extends GameObjectClass {
-  init({
+class Scene {
+  constructor({
     /**
      * The id of the scene.
      * @memberof Scene
@@ -64,6 +73,20 @@ class Scene extends GameObjectClass {
      * @property {String} name
      */
     name = id,
+
+    /**
+     * The children of the scene.
+     * @memberof Scene
+     * @property {{render: Function, update: Function, x: number, y: number}[]} children
+     */
+    children = [],
+
+    /**
+     * The canvas element for the scenes camera. Used to set the width and height of the camera and determine the cameras bounds for culling objects.
+     * @memberof Scene
+     * @property {HTMLCanvasElement} canvas
+     */
+    canvas = getCanvas(),
 
     /**
      * If the camera should cull objects outside the camera bounds. Not rendering objects which can't be seen greatly improves the performance.
@@ -81,6 +104,9 @@ class Scene extends GameObjectClass {
 
     ...props
   }) {
+    this._c = [];
+    this._ctx = canvas.getContext('2d');
+
     // create an accessible DOM node for screen readers (do this first
     // so we can move DOM nodes in addChild)
     // dn = dom node
@@ -90,17 +116,19 @@ class Scene extends GameObjectClass {
     section.id = id;
     section.setAttribute('aria-label', name);
 
-    super.init({
+    addToDom(section, canvas);
+
+    // add all properties to the object, overriding any defaults
+    Object.assign(this, {
       id,
       name,
+      canvas,
       cullObjects,
       cullFunction,
       ...props
     });
 
-    addToDom(section, this.context.canvas);
-
-    let canvas = this.context.canvas;
+    children.map(child => this.addChild(child));
 
     /**
      * The camera object which is used as the focal point for the scene. The scene will not render objects that are outside the bounds of the camera.
@@ -116,17 +144,53 @@ class Scene extends GameObjectClass {
       height: canvas.height,
       anchor: { x: 0.5, y: 0.5 }
     });
+  }
 
-    // can call super here only by using lexical scope
-    this.camera._pc = () => {
-      super._pc.call(this.camera);
+  set children(value) {
+    while (this._c.length) {
+      this.removeChild(this._c[0]);
+    }
+    value.map(value => this.addChild(value));
+  }
 
-      // only set the cameras position based on scale
-      // but not the width/height
-      let canvas = this.context.canvas;
-      this.camera._wx = this.camera.x * this.scaleX;
-      this.camera._wy = this.camera.y * this.scaleY;
-    };
+  get children() {
+    return this._c;
+  }
+
+  /**
+   * Add an object as a child to the scene.
+   * @memberof Scene
+   * @function addChild
+   *
+   * @param {{render: Function, update: Function, x: number, y: number}} child - Object to add as a child.
+   */
+  addChild(child) {
+    this.children.push(child);
+
+    // move all children to be in the scenes DOM node so we can
+    // hide and show the DOM node and thus hide and show all the
+    // children
+    getAllNodes(child).map(node => {
+      this._dn.appendChild(node);
+    });
+  }
+
+  /**
+   * Remove an object as a child of the scene.
+   * @memberof Scene
+   * @function removeChild
+   *
+   * @param {Object} child - Object to remove as a child.
+   */
+  removeChild(child) {
+    let index = this.children.indexOf(child);
+    if (index !== -1) {
+      this.children.splice(index, 1);
+    }
+
+    getAllNodes(child).map(node => {
+      addToDom(node, this.canvas);
+    });
   }
 
   /**
@@ -163,25 +227,6 @@ class Scene extends GameObjectClass {
     this.onHide();
   }
 
-  addChild(object, options) {
-    super.addChild(object, options);
-
-    // move all children to be in the scenes DOM node so we can
-    // hide and show the DOM node and thus hide and show all the
-    // children
-    getAllNodes(object).map(node => {
-      this._dn.appendChild(node);
-    });
-  }
-
-  removeChild(object) {
-    super.removeChild(object);
-
-    getAllNodes(object).map(node => {
-      addToDom(node, this.context.canvas);
-    });
-  }
-
   /**
    * Clean up the scene and call `destroy()` on all children.
    * @memberof Scene
@@ -190,12 +235,6 @@ class Scene extends GameObjectClass {
   destroy() {
     this._dn.remove();
     this.children.map(child => child.destroy && child.destroy());
-  }
-
-  update(dt) {
-    if (!this.hidden) {
-      super.update(dt);
-    }
   }
 
   /**
@@ -218,25 +257,41 @@ class Scene extends GameObjectClass {
 
     this.camera.x = x;
     this.camera.y = y;
-    this._pc();
   }
 
-  _pc() {
-    super._pc();
-
-    // this can be called before the camera is initialized so we
-    // need to guard it
-    this.camera && this.camera._pc();
-  }
-
-  render() {
-    let { x, y, width, height } = this.camera;
-
-    this.sx = x * this.scaleX - width / 2;
-    this.sy = y * this.scaleY - height / 2;
-
+  /**
+   * Update all children of the scene by calling the objects `update()` function.
+   * @memberof Scene
+   * @function update
+   *
+   * @param {Number} [dt] - Time since last update.
+   */
+  update(dt) {
     if (!this.hidden) {
-      super.render(child => (this.cullObjects ? this.cullFunction(child, this.camera) : true));
+      this.children.map(child => child.update && child.update());
+    }
+  }
+
+  /**
+   * Render all children of the scene by calling the objects `render()` function. If [cullObjects](/api/scene#cullObjects) is set to true then only those objects where are inside the camera bounds will be rendered.
+   * @memberof Scene
+   * @function render
+   */
+  render() {
+    if (!this.hidden) {
+      let { _ctx, children, camera, cullObjects, cullFunction } = this;
+      let { x, y, width, height, scaleX, scaleY } = camera;
+
+      // translate the scene to the camera position
+      _ctx.save();
+      _ctx.translate(-(x * scaleX - width / 2), -(y * scaleY - height / 2));
+
+      if (cullObjects) {
+        children = children.filter(child => cullFunction(camera, child));
+      }
+      children.map(child => child.render && child.render());
+
+      _ctx.restore();
     }
   }
 

--- a/src/text.js
+++ b/src/text.js
@@ -3,7 +3,6 @@ import { on } from './events.js';
 import { getCanvas, getContext } from './core.js';
 
 let fontSizeRegex = /(\d+)(\w+)/;
-let dirtyValues = ['text', 'font', 'width'];
 
 function parseFont(font) {
   let match = font.match(fontSizeRegex);

--- a/test/typings/gameObject.ts
+++ b/test/typings/gameObject.ts
@@ -42,7 +42,6 @@ gameObject.update(1/60);
 gameObject.advance();
 gameObject.advance(1/60);
 gameObject.render();
-gameObject.render(() => true);
 gameObject.draw();
 gameObject.setScale(1);
 gameObject.setScale(1, 2);

--- a/test/typings/scene.ts
+++ b/test/typings/scene.ts
@@ -7,6 +7,7 @@ let scene: kontra.Scene = kontra.Scene({
 let id: string = scene.id;
 let name: string = scene.name;
 let hidden: boolean = scene.hidden;
+let canvas: HTMLCanvasElement = scene.canvas;
 let cullObjects: boolean = scene.cullObjects;
 let camera: kontra.GameObject = scene.camera;
 

--- a/test/unit/gameObject.spec.js
+++ b/test/unit/gameObject.spec.js
@@ -375,24 +375,6 @@ describe('gameObject with context: ' + JSON.stringify(testContext, null, 4), () 
 
         expect(child.render.called).to.be.true;
       });
-
-      it('should filter objects by a function if passed', () => {
-        let child1 = {
-          foo: 'bar',
-          render: sinon.stub()
-        };
-        let child2 = {
-          foo: 'baz',
-          render: sinon.stub()
-        };
-
-        gameObject.children = [child1, child2];
-
-        gameObject.render(obj => obj.foo === 'baz');
-
-        expect(child1.render.called).to.be.false;
-        expect(child2.render.called).to.be.true;
-      });
     } else {
       it('should not call render on each child', () => {
         let child = {

--- a/test/unit/helpers.spec.js
+++ b/test/unit/helpers.spec.js
@@ -298,30 +298,6 @@ describe('helpers', () => {
       expect(helpers.collides(sprite1, sprite2)).to.be.true;
     });
 
-    it('should return null if either sprite is rotated', () => {
-      let sprite1 = Sprite({
-        x: 10,
-        y: 20,
-        width: 10,
-        height: 20,
-        rotation: 1
-      });
-
-      let sprite2 = Sprite({
-        x: 19,
-        y: 39,
-        width: 10,
-        height: 20
-      });
-
-      expect(helpers.collides(sprite1, sprite2)).to.equal(null);
-
-      sprite1.rotation = 0;
-      sprite2.rotation = 1;
-
-      expect(helpers.collides(sprite1, sprite2)).to.equal(null);
-    });
-
     it('should work for non-sprite objects', () => {
       let sprite1 = Sprite({
         x: 10,


### PR DESCRIPTION
BREAKING CHANGE:

Closes #267