### PR TITLE
chore: make apis consistent

### DIFF
--- a/src/gameObject.js
+++ b/src/gameObject.js
@@ -222,7 +222,7 @@ class GameObject extends Updatable {
     this._uw();
 
     // @ifdef GAMEOBJECT_GROUP
-    children.map(child => this.addChild(child));
+    this.addChild(children);
     // @endif
 
     // rf = render function
@@ -516,10 +516,8 @@ class GameObject extends Updatable {
 
   // @ifdef GAMEOBJECT_GROUP
   set children(value) {
-    while (this._c.length) {
-      this.removeChild(this._c[0]);
-    }
-    value.map(value => this.addChild(value));
+    this.removeChild(this._c);
+    this.addChild(value);
   }
 
   get children() {
@@ -531,7 +529,7 @@ class GameObject extends Updatable {
    * @memberof GameObject
    * @function addChild
    *
-   * @param {GameObject} child - Object to add as a child.
+   * @param {...(GameObject|GameObject[])[]} objects - Object to add as a child. Can be a single object, an array of objects, or a comma-separated list of objects.
    *
    * @example
    * // exclude-code:start
@@ -566,11 +564,13 @@ class GameObject extends Updatable {
    *
    * parent.render();
    */
-  addChild(child) {
-    this.children.push(child);
-    child.parent = this;
-    child._pc = child._pc || noop;
-    child._pc();
+  addChild(...objects) {
+    objects.flat().map(child => {
+      this.children.push(child);
+      child.parent = this;
+      child._pc = child._pc || noop;
+      child._pc();
+    });
   }
 
   /**
@@ -578,13 +578,15 @@ class GameObject extends Updatable {
    * @memberof GameObject
    * @function removeChild
    *
-   * @param {GameObject} child - Object to remove as a child.
+   * @param {...(GameObject|GameObject[])[]} objects - Object to remove as a child. Can be a single object, an array of objects, or a comma-separated list of objects.
    */
-  removeChild(child) {
-    if (removeFromArray(this.children, child)) {
-      child.parent = null;
-      child._pc();
-    }
+  removeChild(...objects) {
+    objects.flat().map(child => {
+      if (removeFromArray(this.children, child)) {
+        child.parent = null;
+        child._pc();
+      }
+    });
   }
   // @endif
 

--- a/src/gesture.js
+++ b/src/gesture.js
@@ -171,11 +171,13 @@ export function initGesture() {
  * ```
  * @function onGesture
  *
- * @param {String} name - The name of the gesture.
+ * @param {String|String[]} gestures - Gesture or gestures to register callback for.
  * @param {(evt: TouchEvent, touches: Object) => void} callback - Function to call on gesture events.
  */
-export function onGesture(name, callback) {
-  callbacks[name] = callback;
+export function onGesture(gestures, callback) {
+  [].concat(gestures).map(gesture => {
+    callbacks[gesture] = callback;
+  });
 }
 
 /**
@@ -191,8 +193,10 @@ export function onGesture(name, callback) {
  * ```
  * @function offGesture
  *
- * @param {String} name - The name of the gesture.
+ * @param {String|String[]} gestures - Gesture or gestures to unregister callback for.
  */
-export function offGesture(name) {
-  callbacks[name] = 0;
+export function offGesture(gestures) {
+  [].concat(gestures).map(gesture => {
+    callbacks[gesture] = 0;
+  });
 }

--- a/src/pointer.js
+++ b/src/pointer.js
@@ -58,6 +58,13 @@ import { removeFromArray } from './utils.js';
  * @sectionName Pointer
  */
 
+/**
+ * Below is a list of buttons that you can use. If you need to extend or modify this list, you can use the [pointer](api/gamepad#pointerMap) property.
+ *
+ * - left, middle, right
+ * @sectionName Available Buttons
+ */
+
 // save each object as they are rendered to determine which object
 // is on top when multiple objects are the target of an event.
 // we'll always use the last frame's object order so we know
@@ -69,12 +76,20 @@ let callbacks = {};
 let pressedButtons = {};
 
 /**
- * Below is a list of buttons that you can use.
+ * A map of pointer button indices to button names. Modify this object to expand the list of [available buttons](api/pointer#available-buttons).
  *
- * - left, middle, right
- * @sectionName Available Buttons
+ * ```js
+ * import { pointerMap, pointerPressed } from 'kontra';
+ *
+ * pointerMap[2] = 'buttonWest';
+ *
+ * if (pointerPressed('buttonWest')) {
+ *   // handle west face button
+ * }
+ * ```
+ * @property {{[key: number]: String}} pointerMap
  */
-let buttonMap = {
+export let pointerMap = {
   0: 'left',
   1: 'middle',
   2: 'right'
@@ -219,7 +234,7 @@ function getCanvasOffset(pointer) {
  */
 function pointerDownHandler(evt) {
   // touchstart should be treated like a left mouse button
-  let button = evt.button != null ? buttonMap[evt.button] : 'left';
+  let button = evt.button != null ? pointerMap[evt.button] : 'left';
   pressedButtons[button] = true;
   pointerHandler(evt, 'onDown');
 }
@@ -230,7 +245,7 @@ function pointerDownHandler(evt) {
  * @param {MouseEvent|TouchEvent} evt
  */
 function pointerUpHandler(evt) {
-  let button = evt.button != null ? buttonMap[evt.button] : 'left';
+  let button = evt.button != null ? pointerMap[evt.button] : 'left';
   pressedButtons[button] = false;
   pointerHandler(evt, 'onUp');
 }

--- a/src/quadtree.js
+++ b/src/quadtree.js
@@ -213,7 +213,7 @@ class Quadtree {
    * @memberof Quadtree
    * @function add
    *
-   * @param {...({x: Number, y: Number, width: Number, height: Number}|{x: Number, y: Number, width: Number, height: Number}[])[]} objects - Objects to add to the quadtree.
+   * @param {...({x: Number, y: Number, width: Number, height: Number}|{x: Number, y: Number, width: Number, height: Number}[])[]} objects - Objects to add to the quadtree. Can be a single object, an array of objects, or a comma-separated list of objects.
    */
   add(...objects) {
     objects.flat().map(object => {

--- a/src/scene.js
+++ b/src/scene.js
@@ -184,9 +184,7 @@ class Scene {
   }
 
   set objects(value) {
-    while (this._o.length) {
-      this.remove(this._o[0]);
-    }
+    this.remove(this._o);
     this.add(value);
   }
 

--- a/src/tileEngine.js
+++ b/src/tileEngine.js
@@ -204,7 +204,8 @@ class TileEngine {
       // @ifdef TILEENGINE_CAMERA
       _sx: 0,
       _sy: 0,
-      objects: [],
+      // o = objects
+      _o: [],
       // @endif
 
       /**
@@ -249,26 +250,39 @@ class TileEngine {
     this._sy = clamp(0, this.mapheight - getCanvas().height, value);
   }
 
+  set objects(value) {
+    this.remove(this._o);
+    this.add(value);
+  }
+
+  get objects() {
+    return this._o;
+  }
+
   /**
    * Add an object to the tile engine.
    * @memberof TileEngine
-   * @function addObject
+   * @function add
    *
-   * @param {Object} object - Object to add to the tile engine.
+   * @param {...(Object|Object[])[]} objects - Object to add to the tile engine. Can be a single object, an array of objects, or a comma-separated list of objects.
    */
-  addObject(object) {
-    this.objects.push(object);
+  add(...objects) {
+    objects.flat().map(object => {
+      this._o.push(object);
+    });
   }
 
   /**
    * Remove an object from the tile engine.
    * @memberof TileEngine
-   * @function removeObject
+   * @function remove
    *
-   * @param {Object} object - Object to remove from the tile engine.
+   * @param {...(Object|Object[])[]} objects - Object to remove from the tile engine. Can be a single object, an array of objects, or a comma-separated list of objects.
    */
-  removeObject(object) {
-    removeFromArray(this.objects, object);
+  remove(...objects) {
+    objects.flat().map(object => {
+      removeFromArray(this._o, object);
+    });
   }
   // @endif
 

--- a/test/integration/scene.spec.js
+++ b/test/integration/scene.spec.js
@@ -4,7 +4,7 @@ import TileEngine from '../../src/tileEngine.js';
 import { init, getCanvas } from '../../src/core.js';
 import { depthSort } from '../../src/helpers.js';
 
-describe('Scene integration', () => {
+describe('scene integration', () => {
   before(() => {
     if (!getCanvas()) {
       let canvas = document.createElement('canvas');

--- a/test/typings/gameObject.ts
+++ b/test/typings/gameObject.ts
@@ -36,7 +36,11 @@ let world: {
 
 let alive: boolean = gameObject.isAlive();
 gameObject.addChild(kontra.GameObject());
+gameObject.addChild(kontra.GameObject(), kontra.GameObject());
+gameObject.addChild([kontra.GameObject(), kontra.GameObject()]);
 gameObject.removeChild(kontra.GameObject());
+gameObject.removeChild(kontra.GameObject(), kontra.GameObject());
+gameObject.removeChild([kontra.GameObject(), kontra.GameObject()]);
 gameObject.update();
 gameObject.update(1/60);
 gameObject.advance();

--- a/test/typings/gesture.ts
+++ b/test/typings/gesture.ts
@@ -38,4 +38,7 @@ kontra.gestureMap.baz = {
 kontra.onGesture('panleft', (evt: TouchEvent, touches: object) => {
   console.log('panleft');
 });
+kontra.onGesture(['panleft', 'swiperight'], () => {})
+
 kontra.offGamepad('panleft');
+kontra.offGamepad(['panleft', 'swiperight']);

--- a/test/typings/tileEngine.ts
+++ b/test/typings/tileEngine.ts
@@ -44,10 +44,14 @@ let tileRow: number = tileEngine.tileAtLayer('ground', {row: 5, col: 5});
 tileEngine.setTileAtLayer('ground', {x: 50, y: 50}, 2);
 tileEngine.setTileAtLayer('ground', {row: 5, col: 5}, 2);
 tileEngine.setLayer('ground', [1,2,0,0,0,5,6]);
-tileEngine.addObject({});
-tileEngine.addObject(kontra.GameObject());
-tileEngine.removeObject({});
-tileEngine.removeObject(kontra.GameObject());
+tileEngine.add({});
+tileEngine.add({}, {});
+tileEngine.add([{}, {}]);
+tileEngine.add(kontra.GameObject());
+tileEngine.remove({});
+tileEngine.remove({}, {});
+tileEngine.remove([{}, {}]);
+tileEngine.remove(kontra.GameObject());
 
 // options
 kontra.TileEngine({

--- a/test/unit/gameObject.spec.js
+++ b/test/unit/gameObject.spec.js
@@ -120,9 +120,7 @@ describe(
 
           gameObject = GameObject({ children: ['child1', 'child2'] });
 
-          expect(spy.calledTwice).to.be.true;
-          expect(spy.firstCall.calledWith('child1')).to.be.true;
-          expect(spy.secondCall.calledWith('child2')).to.be.true;
+          expect(spy.calledWith(['child1', 'child2'])).to.be.true;
         });
       } else {
         it('should not default children', () => {
@@ -693,6 +691,26 @@ describe(
             expect(gameObject.children).deep.equal([child]);
           });
 
+          it('should add multiple objects as a child', () => {
+            let child1 = {
+              foo: 'bar'
+            };
+            let child2 = {};
+            gameObject.addChild(child1, child2);
+
+            expect(gameObject.children).deep.equal([child1, child2]);
+          });
+
+          it('should add an array objects as a child', () => {
+            let child1 = {
+              foo: 'bar'
+            };
+            let child2 = {};
+            gameObject.addChild([child1, child2]);
+
+            expect(gameObject.children).deep.equal([child1, child2]);
+          });
+
           it('should set the childs parent to the game object', () => {
             let child = {
               foo: 'bar'
@@ -734,6 +752,28 @@ describe(
             gameObject.removeChild(child);
 
             expect(gameObject.children.length).to.equal(0);
+          });
+
+          it('should add multiple objects as a child', () => {
+            let child1 = {
+              foo: 'bar'
+            };
+            let child2 = {};
+            gameObject.addChild(child1, child2);
+            gameObject.removeChild(child1, child2);
+
+            expect(gameObject.children).deep.equal([]);
+          });
+
+          it('should add an array objects as a child', () => {
+            let child1 = {
+              foo: 'bar'
+            };
+            let child2 = {};
+            gameObject.addChild(child1, child2);
+            gameObject.removeChild([child1, child2]);
+
+            expect(gameObject.children).deep.equal([]);
           });
 
           it('should remove the childs parent', () => {
@@ -794,10 +834,11 @@ describe(
               thing1: 'thing2'
             };
 
+            let oldChildren = gameObject.children;
             gameObject.children = [child];
 
-            expect(removeSpy.calledThrice).to.be.true;
-            expect(addSpy.calledWith(child)).to.be.true;
+            expect(removeSpy.calledWith(oldChildren)).to.be.true;
+            expect(addSpy.calledWith([child])).to.be.true;
             expect(gameObject.children.length).to.equal(1);
             expect(gameObject.children[0]).to.equal(child);
           });

--- a/test/unit/gamepad.spec.js
+++ b/test/unit/gamepad.spec.js
@@ -35,7 +35,6 @@ describe('gamepad', () => {
   });
 
   it('should export api', () => {
-    expect(gamepad.gamepadMap).to.be.an('object');
     expect(gamepad.gamepadMap).to.deep.equal({
       0: 'south',
       1: 'east',

--- a/test/unit/gesture.spec.js
+++ b/test/unit/gesture.spec.js
@@ -13,7 +13,11 @@ describe('gesture', () => {
   });
 
   it('should export api', () => {
-    expect(gesture.gestureMap).to.be.an('object');
+    expect(Object.keys(gesture.gestureMap)).to.deep.equal([
+      'swipe',
+      'pinch'
+    ]);
+
     expect(gesture.initGesture).to.be.an('function');
     expect(gesture.onGesture).to.be.an('function');
     expect(gesture.offGesture).to.be.an('function');
@@ -55,6 +59,13 @@ describe('gesture', () => {
       gesture.onGesture('swipeleft', foo);
       expect(gesture.callbacks.swipeleft).to.equal(foo);
     });
+
+    it('should add an array of listeners', () => {
+      function foo() {}
+      gesture.onGesture(['swipeleft', 'swiperight'], foo);
+      expect(gesture.callbacks.swipeleft).to.equal(foo);
+      expect(gesture.callbacks.swiperight).to.equal(foo);
+    });
   });
 
   // --------------------------------------------------
@@ -70,6 +81,14 @@ describe('gesture', () => {
       gesture.onGesture('swipeleft', foo);
       gesture.offGesture('swipeleft', foo);
       expect(gesture.callbacks.swipeleft).to.equal(0);
+    });
+
+    it('should remove an array of listeners', () => {
+      function foo() {}
+      gesture.onGesture(['swipeleft', 'swiperight'], foo);
+      gesture.offGesture(['swipeleft', 'swiperight'], foo);
+      expect(gesture.callbacks.swipeleft).to.equal(0);
+      expect(gesture.callbacks.swiperight).to.equal(0);
     });
   });
 

--- a/test/unit/keyboard.spec.js
+++ b/test/unit/keyboard.spec.js
@@ -11,7 +11,65 @@ describe('keyboard', () => {
   });
 
   it('should export api', () => {
-    expect(keyboard.keyMap).to.be.an('object');
+    // full keyMap api is only exported after initKeys
+    keyboard.initKeys();
+
+    expect(keyboard.keyMap).to.deep.equal({
+      Enter: 'enter',
+      Escape: 'esc',
+      Space: 'space',
+      ArrowLeft: 'arrowleft',
+      ArrowUp: 'arrowup',
+      ArrowRight: 'arrowright',
+      ArrowDown: 'arrowdown',
+      KeyA: 'a',
+      KeyB: 'b',
+      KeyC: 'c',
+      KeyD: 'd',
+      KeyE: 'e',
+      KeyF: 'f',
+      KeyG: 'g',
+      KeyH: 'h',
+      KeyI: 'i',
+      KeyJ: 'j',
+      KeyK: 'k',
+      KeyL: 'l',
+      KeyM: 'm',
+      KeyN: 'n',
+      KeyO: 'o',
+      KeyP: 'p',
+      KeyQ: 'q',
+      KeyR: 'r',
+      KeyS: 's',
+      KeyT: 't',
+      KeyU: 'u',
+      KeyV: 'v',
+      KeyW: 'w',
+      KeyX: 'x',
+      KeyY: 'y',
+      KeyZ: 'z',
+      Numpad0: '0',
+      Digit0: '0',
+      Numpad1: '1',
+      Digit1: '1',
+      Numpad2: '2',
+      Digit2: '2',
+      Numpad3: '3',
+      Digit3: '3',
+      Numpad4: '4',
+      Digit4: '4',
+      Numpad5: '5',
+      Digit5: '5',
+      Numpad6: '6',
+      Digit6: '6',
+      Numpad7: '7',
+      Digit7: '7',
+      Numpad8: '8',
+      Digit8: '8',
+      Numpad9: '9',
+      Digit9: '9'
+    });
+
     expect(keyboard.initKeys).to.be.an('function');
     expect(keyboard.onKey).to.be.an('function');
     expect(keyboard.offKey).to.be.an('function');

--- a/test/unit/pointer.spec.js
+++ b/test/unit/pointer.spec.js
@@ -37,6 +37,12 @@ describe('pointer', () => {
   });
 
   it('should export api', () => {
+    expect(pointer.pointerMap).to.deep.equal({
+      0: 'left',
+      1: 'middle',
+      2: 'right'
+    });
+
     expect(pointer.getPointer).to.be.an('function');
     expect(pointer.initPointer).to.be.an('function');
     expect(pointer.track).to.be.an('function');

--- a/test/unit/scene.spec.js
+++ b/test/unit/scene.spec.js
@@ -374,9 +374,10 @@ describe('scene', () => {
         thing1: 'thing2'
       };
 
+      let oldObjects = scene.objects;
       scene.objects = [object];
 
-      expect(removeSpy.calledThrice).to.be.true;
+      expect(removeSpy.calledWith(oldObjects)).to.be.true;
       expect(addSpy.calledWith([object])).to.be.true;
       expect(scene.objects.length).to.equal(1);
       expect(scene.objects[0]).to.equal(object);

--- a/test/unit/tileEngine.spec.js
+++ b/test/unit/tileEngine.spec.js
@@ -141,7 +141,7 @@ describe(
             render: spy
           };
 
-          tileEngine.addObject(obj);
+          tileEngine.add(obj);
           tileEngine.render();
 
           expect(spy.called).to.be.true;
@@ -773,9 +773,52 @@ describe(
     });
 
     // --------------------------------------------------
-    // tileEngine.addObject
+    // tileEngine.children
     // --------------------------------------------------
-    describe('addObject', () => {
+    describe('children', () => {
+      it('should properly handle setting children', () => {
+        let tileEngine = TileEngine({
+          tilewidth: 10,
+          tileheight: 10,
+          width: 100,
+          height: 100,
+          tilesets: [
+            {
+              image: new Image()
+            }
+          ],
+          layers: [
+            {
+              name: 'test',
+              data: [0, 0, 1, 0, 0]
+            }
+          ]
+        });
+
+        tileEngine.add({ foo: 'bar' });
+        tileEngine.add({ faz: 'baz' });
+        tileEngine.add({ hello: 'world' });
+
+        let removeSpy = sinon.spy(tileEngine, 'remove');
+        let addSpy = sinon.spy(tileEngine, 'add');
+        let child = {
+          thing1: 'thing2'
+        };
+
+        let oldObjects = tileEngine.objects;
+        tileEngine.objects = [child];
+
+        expect(removeSpy.calledWith(oldObjects)).to.be.true;
+        expect(addSpy.calledWith([child])).to.be.true;
+        expect(tileEngine.objects.length).to.equal(1);
+        expect(tileEngine.objects[0]).to.equal(child);
+      });
+    });
+
+    // --------------------------------------------------
+    // tileEngine.add
+    // --------------------------------------------------
+    describe('add', () => {
       let tileEngine = null;
       let obj = null;
 
@@ -803,20 +846,30 @@ describe(
       if (testContext.TILEENGINE_CAMERA) {
         it('should add object', () => {
           expect(tileEngine.objects.length).to.equal(0);
-          tileEngine.addObject(obj);
+          tileEngine.add(obj);
           expect(tileEngine.objects.length).to.equal(1);
+        });
+
+        it('should add multiple objects', () => {
+          tileEngine.add(obj, {});
+          expect(tileEngine.objects.length).to.equal(2);
+        });
+
+        it('should add an array of objects', () => {
+          tileEngine.add([obj, {}]);
+          expect(tileEngine.objects.length).to.equal(2);
         });
       } else {
         it('should not exist', () => {
-          expect(tileEngine.addObject).to.not.exist;
+          expect(tileEngine.add).to.not.exist;
         });
       }
     });
 
     // --------------------------------------------------
-    // tileEngine.removeObject
+    // tileEngine.remove
     // --------------------------------------------------
-    describe('removeObject', () => {
+    describe('remove', () => {
       let tileEngine = null;
       let obj = null;
 
@@ -843,21 +896,35 @@ describe(
 
       if (testContext.TILEENGINE_CAMERA) {
         it('should remove object', () => {
-          tileEngine.addObject(obj);
-          tileEngine.removeObject(obj);
+          tileEngine.add(obj);
+          tileEngine.remove(obj);
+          expect(tileEngine.objects.length).to.equal(0);
+        });
+
+        it('should remove multiple objects', () => {
+          let obj2 = {};
+          tileEngine.add(obj, obj2);
+          tileEngine.remove(obj, obj2);
+          expect(tileEngine.objects.length).to.equal(0);
+        });
+
+        it('should remove an array of objects', () => {
+          let obj2 = {};
+          tileEngine.add(obj, obj2);
+          tileEngine.remove([obj, obj2]);
           expect(tileEngine.objects.length).to.equal(0);
         });
 
         it('should not error if the object was not added before', () => {
           function fn() {
-            tileEngine.removeObject(obj);
+            tileEngine.remove(obj);
           }
 
           expect(fn).to.not.throw();
         });
       } else {
         it('should not exist', () => {
-          expect(tileEngine.removeObject).to.not.exist;
+          expect(tileEngine.remove).to.not.exist;
         });
       }
     });

--- a/test/unit/tileEngine.spec.js
+++ b/test/unit/tileEngine.spec.js
@@ -773,11 +773,13 @@ describe(
     });
 
     // --------------------------------------------------
-    // tileEngine.children
+    // tileEngine.objects
     // --------------------------------------------------
-    describe('children', () => {
-      it('should properly handle setting children', () => {
-        let tileEngine = TileEngine({
+    describe('objects', () => {
+      let tileEngine = null;
+
+      beforeEach(() => {
+        tileEngine = TileEngine({
           tilewidth: 10,
           tileheight: 10,
           width: 100,
@@ -794,25 +796,33 @@ describe(
             }
           ]
         });
-
-        tileEngine.add({ foo: 'bar' });
-        tileEngine.add({ faz: 'baz' });
-        tileEngine.add({ hello: 'world' });
-
-        let removeSpy = sinon.spy(tileEngine, 'remove');
-        let addSpy = sinon.spy(tileEngine, 'add');
-        let child = {
-          thing1: 'thing2'
-        };
-
-        let oldObjects = tileEngine.objects;
-        tileEngine.objects = [child];
-
-        expect(removeSpy.calledWith(oldObjects)).to.be.true;
-        expect(addSpy.calledWith([child])).to.be.true;
-        expect(tileEngine.objects.length).to.equal(1);
-        expect(tileEngine.objects[0]).to.equal(child);
       });
+
+      if (testContext.TILEENGINE_CAMERA) {
+        it('should properly handle setting objects', () => {
+          tileEngine.add({ foo: 'bar' });
+          tileEngine.add({ faz: 'baz' });
+          tileEngine.add({ hello: 'world' });
+
+          let removeSpy = sinon.spy(tileEngine, 'remove');
+          let addSpy = sinon.spy(tileEngine, 'add');
+          let child = {
+            thing1: 'thing2'
+          };
+
+          let oldObjects = tileEngine.objects;
+          tileEngine.objects = [child];
+
+          expect(removeSpy.calledWith(oldObjects)).to.be.true;
+          expect(addSpy.calledWith([child])).to.be.true;
+          expect(tileEngine.objects.length).to.equal(1);
+          expect(tileEngine.objects[0]).to.equal(child);
+        });
+      } else {
+        it('should not have objects', () => {
+          expect(tileEngine.objects).to.not.exist;
+        });
+      }
     });
 
     // --------------------------------------------------


### PR DESCRIPTION
All input APIs are similarly named and take about the same type of parameters. All classes with children / objects have similar add/remove apis and can now all take a single object, an array of objects, or a comma-separated list of objects.