### PR TITLE
Fix gameLoop unit test rounding issue

### DIFF
--- a/test/unit/gameLoop.spec.js
+++ b/test/unit/gameLoop.spec.js
@@ -255,7 +255,7 @@ describe('gameLoop', () => {
         render: noop
       });
       simulateEvent('blur');
-      loop._last = performance.now() - 1e3 / 60;
+      loop._last = performance.now() - Math.ceil(1e3 / 60);
       loop._frame();
 
       throw new Error('should not get here');


### PR DESCRIPTION
Fixes an issue where dodgy floating point rounding/addition would result in `GameLoop.update()` (and therefore `done()`) never being called in the `'should update if page is blurred when blur is true'` gameLoop test.

[Discussion is on the Js13kGames Slack](https://js13kgames.slack.com/archives/C018KMA4UUD/p1647273749781259)

There's no issue on GitHub for this - I've gone straight in for a Pull Request - hopefully as it's such a minor change that's okay 😀