### PR TITLE
Add TileEngineClass to exports

### DIFF
--- a/src/kontra.defaults.js
+++ b/src/kontra.defaults.js
@@ -78,7 +78,7 @@ import Scene, { SceneClass } from './scene.js';
 import Sprite, { SpriteClass } from './sprite.js';
 import SpriteSheet, { SpriteSheetClass } from './spriteSheet.js';
 import Text, { TextClass } from './text.js';
-import TileEngine from './tileEngine.js';
+import TileEngine, { TileEngineClass } from './tileEngine.js';
 import Vector, { VectorClass } from './vector.js';
 
 let kontra = {
@@ -185,6 +185,7 @@ let kontra = {
   TextClass,
 
   TileEngine,
+  TileEngineClass,
 
   Vector,
   VectorClass

--- a/src/kontra.js
+++ b/src/kontra.js
@@ -84,6 +84,6 @@ export {
   SpriteSheetClass
 } from './spriteSheet.js';
 export { default as Text, TextClass } from './text.js';
-export { default as TileEngine } from './tileEngine.js';
+export { default as TileEngine, TileEngineClass } from './tileEngine.js';
 export { default as Vector, VectorClass } from './vector.js';
 export { default } from './kontra.defaults.js';


### PR DESCRIPTION
Fixes https://github.com/straker/kontra/issues/291

Tested in [my own little repo](https://github.com/burntcustard/kontra-gh-pages-iso-test/blob/main/src/js/main.js) where I've imported TileEngineClass and overridden `TileEngine._r()` to allow isometric rendering (kind of) of tiles