### PR TITLE
tests: ensure class exports exist for various Kontra exports

### DIFF
--- a/test/unit/kontra.defaults.spec.js
+++ b/test/unit/kontra.defaults.spec.js
@@ -4,8 +4,9 @@ import kontra from '../../src/kontra.defaults.js';
 // kontra.defaults
 // --------------------------------------------------
 describe('kontra.defaults', () => {
-  it('should add animation api', () => {
+  it('should add animation api and class', () => {
     expect(kontra.Animation).to.exist;
+    expect(kontra.AnimationClass).to.exist;
   });
 
   it('should add assets api', () => {
@@ -21,8 +22,9 @@ describe('kontra.defaults', () => {
     expect(kontra.load).to.exist;
   });
 
-  it('should add button api', () => {
+  it('should add button api and class', () => {
     expect(kontra.Button).to.exist;
+    expect(kontra.ButtonClass).to.exist;
   });
 
   it('should add core api', () => {
@@ -41,8 +43,9 @@ describe('kontra.defaults', () => {
     expect(kontra.GameLoop).to.exist;
   });
 
-  it('should add gameObject api', () => {
+  it('should add gameObject api class', () => {
     expect(kontra.GameObject).to.exist;
+    expect(kontra.GameObjectClass).to.exist;
   });
 
   it('should add gamepad api', () => {
@@ -62,8 +65,9 @@ describe('kontra.defaults', () => {
     expect(kontra.offGesture).to.exist;
   });
 
-  it('should add grid api', () => {
+  it('should add grid api and class', () => {
     expect(kontra.Grid).to.exist;
+    expect(kontra.GridClass).to.exist;
   });
 
   it('should add helpers api', () => {
@@ -109,35 +113,43 @@ describe('kontra.defaults', () => {
     expect(kontra.pointerPressed).to.exist;
   });
 
-  it('should add pool api', () => {
+  it('should add pool api and class', () => {
     expect(kontra.Pool).to.exist;
+    expect(kontra.PoolClass).to.exist;
   });
 
-  it('should add quadtree api', () => {
+  it('should add quadtree api and class', () => {
     expect(kontra.Quadtree).to.exist;
+    expect(kontra.QuadtreeClass).to.exist;
   });
 
-  it('should add scene api', () => {
+  it('should add scene api and class', () => {
     expect(kontra.Scene).to.exist;
+    expect(kontra.SceneClass).to.exist;
   });
 
-  it('should add sprite api', () => {
+  it('should add sprite api and class', () => {
     expect(kontra.Sprite).to.exist;
+    expect(kontra.SpriteClass).to.exist;
   });
 
-  it('should add spriteSheet api', () => {
+  it('should add spriteSheet api and class', () => {
     expect(kontra.SpriteSheet).to.exist;
+    expect(kontra.SpriteSheetClass).to.exist;
   });
 
-  it('should add text api', () => {
+  it('should add text api and class', () => {
     expect(kontra.Text).to.exist;
+    expect(kontra.TextClass).to.exist;
   });
 
-  it('should add tileEngine api', () => {
+  it('should add tileEngine api and class', () => {
     expect(kontra.TileEngine).to.exist;
+    expect(kontra.TileEngineClass).to.exist;
   });
 
-  it('should add vector api', () => {
+  it('should add vector api and class', () => {
     expect(kontra.Vector).to.exist;
+    expect(kontra.VectorClass).to.exist;
   });
 });

--- a/test/unit/kontra.defaults.spec.js
+++ b/test/unit/kontra.defaults.spec.js
@@ -43,7 +43,7 @@ describe('kontra.defaults', () => {
     expect(kontra.GameLoop).to.exist;
   });
 
-  it('should add gameObject api class', () => {
+  it('should add gameObject api and class', () => {
     expect(kontra.GameObject).to.exist;
     expect(kontra.GameObjectClass).to.exist;
   });

--- a/test/unit/kontra.spec.js
+++ b/test/unit/kontra.spec.js
@@ -40,24 +40,6 @@ describe('kontra', () => {
     expect(kontraExports.emit).to.exist;
   });
 
-  it('should export helpers api', () => {
-    expect(kontraExports.degToRad).to.exist;
-    expect(kontraExports.radToDeg).to.exist;
-    expect(kontraExports.angleToTarget).to.exist;
-    expect(kontraExports.rotatePoint).to.exist;
-    expect(kontraExports.movePoint).to.exist;
-    expect(kontraExports.randInt).to.exist;
-    expect(kontraExports.seedRand).to.exist;
-    expect(kontraExports.lerp).to.exist;
-    expect(kontraExports.inverseLerp).to.exist;
-    expect(kontraExports.clamp).to.exist;
-    expect(kontraExports.getStoreItem).to.exist;
-    expect(kontraExports.setStoreItem).to.exist;
-    expect(kontraExports.collides).to.exist;
-    expect(kontraExports.getWorldRect).to.exist;
-    expect(kontraExports.depthSort).to.exist;
-  });
-
   it('should export gameLoop api', () => {
     expect(kontraExports.GameLoop).to.exist;
   });
@@ -87,6 +69,24 @@ describe('kontra', () => {
   it('should export grid api and class', () => {
     expect(kontraExports.Grid).to.exist;
     expect(kontraExports.GridClass).to.exist;
+  });
+
+  it('should export helpers api', () => {
+    expect(kontraExports.degToRad).to.exist;
+    expect(kontraExports.radToDeg).to.exist;
+    expect(kontraExports.angleToTarget).to.exist;
+    expect(kontraExports.rotatePoint).to.exist;
+    expect(kontraExports.movePoint).to.exist;
+    expect(kontraExports.randInt).to.exist;
+    expect(kontraExports.seedRand).to.exist;
+    expect(kontraExports.lerp).to.exist;
+    expect(kontraExports.inverseLerp).to.exist;
+    expect(kontraExports.clamp).to.exist;
+    expect(kontraExports.getStoreItem).to.exist;
+    expect(kontraExports.setStoreItem).to.exist;
+    expect(kontraExports.collides).to.exist;
+    expect(kontraExports.getWorldRect).to.exist;
+    expect(kontraExports.depthSort).to.exist;
   });
 
   it('should export keyboard api', () => {

--- a/test/unit/kontra.spec.js
+++ b/test/unit/kontra.spec.js
@@ -5,8 +5,9 @@ import kontra from '../../src/kontra.defaults.js';
 // kontra
 // --------------------------------------------------
 describe('kontra', () => {
-  it('should export animation api', () => {
+  it('should export animation api and class', () => {
     expect(kontraExports.Animation).to.exist;
+    expect(kontraExports.AnimationClass).to.exist;
   });
 
   it('should export assets api', () => {
@@ -22,8 +23,9 @@ describe('kontra', () => {
     expect(kontraExports.load).to.exist;
   });
 
-  it('should export button api', () => {
+  it('should export button api and class', () => {
     expect(kontraExports.Button).to.exist;
+    expect(kontraExports.ButtonClass).to.exist;
   });
 
   it('should export core api', () => {
@@ -60,11 +62,12 @@ describe('kontra', () => {
     expect(kontraExports.GameLoop).to.exist;
   });
 
-  it('should export gameObject api', () => {
+  it('should export gameObject api and class', () => {
     expect(kontraExports.GameObject).to.exist;
+    expect(kontraExports.GameObjectClass).to.exist;
   });
 
-  it('should add gamepad api', () => {
+  it('should export gamepad api', () => {
     expect(kontraExports.gamepadMap).to.exist;
     expect(kontraExports.updateGamepad).to.exist;
     expect(kontraExports.initGamepad).to.exist;
@@ -74,15 +77,16 @@ describe('kontra', () => {
     expect(kontraExports.gamepadAxis).to.exist;
   });
 
-  it('should add gesture api', () => {
+  it('should export gesture api', () => {
     expect(kontraExports.gestureMap).to.exist;
     expect(kontraExports.initGesture).to.exist;
     expect(kontraExports.onGesture).to.exist;
     expect(kontraExports.offGesture).to.exist;
   });
 
-  it('should export grid api', () => {
+  it('should export grid api and class', () => {
     expect(kontraExports.Grid).to.exist;
+    expect(kontraExports.GridClass).to.exist;
   });
 
   it('should export keyboard api', () => {
@@ -110,36 +114,44 @@ describe('kontra', () => {
     expect(kontraExports.pointerPressed).to.exist;
   });
 
-  it('should export pool api', () => {
+  it('should export pool api and class', () => {
     expect(kontraExports.Pool).to.exist;
+    expect(kontraExports.PoolClass).to.exist;
   });
 
-  it('should export quadtree api', () => {
+  it('should export quadtree api and class', () => {
     expect(kontraExports.Quadtree).to.exist;
+    expect(kontraExports.QuadtreeClass).to.exist;
   });
 
-  it('should add scene api', () => {
+  it('should export scene api and class', () => {
     expect(kontraExports.Scene).to.exist;
+    expect(kontraExports.SceneClass).to.exist;
   });
 
-  it('should export sprite api', () => {
+  it('should export sprite api and class', () => {
     expect(kontraExports.Sprite).to.exist;
+    expect(kontraExports.SpriteClass).to.exist;
   });
 
-  it('should export spriteSheet api', () => {
+  it('should export spriteSheet api and class', () => {
     expect(kontraExports.SpriteSheet).to.exist;
+    expect(kontraExports.SpriteSheetClass).to.exist;
   });
 
-  it('should export text api', () => {
+  it('should export text api and class', () => {
     expect(kontraExports.Text).to.exist;
+    expect(kontraExports.TextClass).to.exist;
   });
 
-  it('should export tileEngine api', () => {
+  it('should export tileEngine api and class', () => {
     expect(kontraExports.TileEngine).to.exist;
+    expect(kontraExports.TileEngineClass).to.exist;
   });
 
-  it('should export vector api', () => {
+  it('should export vector api and class', () => {
     expect(kontraExports.Vector).to.exist;
+    expect(kontraExports.VectorClass).to.exist;
   });
 
   it('should export kontra object', () => {

--- a/test/unit/tileEngine.spec.js
+++ b/test/unit/tileEngine.spec.js
@@ -1,4 +1,4 @@
-import TileEngine from '../../src/tileEngine.js';
+import TileEngine, { TileEngineClass } from '../../src/tileEngine.js';
 import { getContext } from '../../src/core.js';
 import { noop } from '../../src/utils.js';
 
@@ -16,6 +16,10 @@ let testContext = {
 describe(
   'tileEngine with context: ' + JSON.stringify(testContext, null, 4),
   () => {
+    it('should export class', () => {
+      expect(TileEngineClass).to.be.a('function');
+    });
+
     // --------------------------------------------------
     // tileEngine.init
     // --------------------------------------------------


### PR DESCRIPTION
"... and class" is perhaps unnecessary, but not every export test tests classes, so I thought it might be worth specifying.

Unfortunately test code coverage isn't affected by these additions 😂