### PR TITLE
feat(helper): return correct angle from angleToTarget

### DIFF
--- a/src/helpers.js
+++ b/src/helpers.js
@@ -67,13 +67,7 @@ export function radToDeg(rad) {
  * @returns {Number} Angle (in radians) from the source point to the target point.
  */
 export function angleToTarget(source, target) {
-  // atan2 returns the counter-clockwise angle in respect to the
-  // x-axis, but the canvas rotation system is based on the y-axis
-  // (rotation of 0 = up). so we need to add a quarter rotation to
-  // return a counter-clockwise rotation in respect to the y-axis
-  return (
-    Math.atan2(target.y - source.y, target.x - source.x) + Math.PI / 2
-  );
+  return Math.atan2(target.y - source.y, target.x - source.x);
 }
 
 /**
@@ -107,8 +101,8 @@ export function rotatePoint(point, angle) {
  */
 export function movePoint(point, angle, distance) {
   return {
-    x: point.x + Math.sin(angle) * distance,
-    y: point.y - Math.cos(angle) * distance
+    x: point.x + Math.cos(angle) * distance,
+    y: point.y + Math.sin(angle) * distance
   };
 }
 

--- a/test/integration/vector.spec.js
+++ b/test/integration/vector.spec.js
@@ -21,7 +21,7 @@ describe('vector integration', () => {
   it('should set from movePoint', () => {
     let vector = Vector(movePoint({ x: 10, y: 10 }, 0, 10));
 
-    expect(vector.x).to.equal(10);
-    expect(vector.y).to.equal(0);
+    expect(vector.x).to.equal(20);
+    expect(vector.y).to.equal(10);
   });
 });

--- a/test/unit/helpers.spec.js
+++ b/test/unit/helpers.spec.js
@@ -48,12 +48,8 @@ describe('helpers', () => {
     it('should return the angle to the target', () => {
       let source = { x: 300, y: 300 };
       let target = { x: 100, y: 100 };
-      expect(
-        helpers.angleToTarget(source, target).toFixed(2)
-      ).to.equal('-0.79');
-      expect(
-        helpers.angleToTarget(target, source).toFixed(2)
-      ).to.equal('2.36');
+      expect(helpers.angleToTarget(source, target)).to.equal(-Math.PI * 3/4);
+      expect(helpers.angleToTarget(target, source)).to.equal(Math.PI / 4);
     });
   });
 
@@ -76,10 +72,17 @@ describe('helpers', () => {
   describe('movePoint', () => {
     it('should return the new x and y after move', () => {
       let point = { x: 300, y: 300 };
-      let angle = helpers.degToRad(35);
-      let newPoint = helpers.movePoint(point, angle, 100);
-      expect(newPoint.x.toFixed(2)).to.equal('357.36');
-      expect(newPoint.y.toFixed(2)).to.equal('218.08');
+      let newPoint = helpers.movePoint(point, -Math.PI * 3/4, 141.421);
+      expect(newPoint.x).to.be.closeTo(200, 0.1);
+      expect(newPoint.y).to.be.closeTo(200, 0.1);
+
+      newPoint = helpers.movePoint(point, Math.PI / 4, 141.421);
+      expect(newPoint.x).to.be.closeTo(400, 0.1);
+      expect(newPoint.y).to.be.closeTo(400, 0.1);
+
+      newPoint = helpers.movePoint(point, Math.PI, 100);
+      expect(newPoint.x).to.be.closeTo(200, 0.1);
+      expect(newPoint.y).to.be.closeTo(300, 0.1);
     });
   });
 


### PR DESCRIPTION
BREAKING CHANGE: The angle returned from `angleToTarget` no longer applies a quarter rotation to the final angle. Previous calculations to determine x and y from the returned angle will now return the wrong values.

Also updates `movePoint` to handle the change to the angle returned from `angleToTarget`.

Closes #312