### PR TITLE
feat(gamepad): pass buttonName as extra param to gamepad callback

### DIFF
--- a/src/gamepad.js
+++ b/src/gamepad.js
@@ -219,10 +219,10 @@ export function initGamepad() {
  *
  * initGamepad();
  *
- * onGamepad('start', function(gamepad, button) {
+ * onGamepad('start', function(gamepad, button, {buttonName}) {
  *   // pause the game
  * });
- * onGamepad(['south', 'rightstick'], function(gamepad, button) {
+ * onGamepad(['south', 'rightstick'], function(gamepad, button, {buttonName}) {
  *   // fire gun
  * });
  *
@@ -235,7 +235,7 @@ export function initGamepad() {
  * @function onGamepad
  *
  * @param {String|String[]} buttons - Button or buttons to register callback for.
- * @param {(gamepad: Gamepad, button: GamepadButton) => void} callback - The function to be called when the button is pressed.
+ * @param {(gamepad: Gamepad, button: GamepadButton, {buttonName}: {buttonName: string}) => void} callback - The function to be called when the button is pressed.
  * @param {Object} [options] - Register options.
  * @param {Number} [options.gamepad] - Gamepad index. Defaults to registerting for all gamepads.
  * @param {'gamepaddown'|'gamepadup'} [options.handler='gamepaddown'] - Whether to register to the gamepaddown or gamepadup event.

--- a/src/gamepad.js
+++ b/src/gamepad.js
@@ -164,7 +164,7 @@ export function updateGamepad() {
           gamepaddownCallbacks[gamepad.index],
           gamepaddownCallbacks
         ].map(callback => {
-          callback?.[buttonName]?.(gamepad, button, { buttonName });
+          callback?.[buttonName]?.(gamepad, button, buttonName);
         });
       }
       // if the button was pressed before and is now not pressed
@@ -172,7 +172,7 @@ export function updateGamepad() {
       else if (state && !pressed) {
         [gamepadupCallbacks[gamepad.index], gamepadupCallbacks].map(
           callback => {
-            callback?.[buttonName]?.(gamepad, button, { buttonName });
+            callback?.[buttonName]?.(gamepad, button, buttonName);
           }
         );
       }
@@ -219,10 +219,10 @@ export function initGamepad() {
  *
  * initGamepad();
  *
- * onGamepad('start', function(gamepad, button, {buttonName}) {
+ * onGamepad('start', function(gamepad, button, buttonName) {
  *   // pause the game
  * });
- * onGamepad(['south', 'rightstick'], function(gamepad, button, {buttonName}) {
+ * onGamepad(['south', 'rightstick'], function(gamepad, button, buttonName) {
  *   // fire gun
  * });
  *
@@ -235,7 +235,7 @@ export function initGamepad() {
  * @function onGamepad
  *
  * @param {String|String[]} buttons - Button or buttons to register callback for.
- * @param {(gamepad: Gamepad, button: GamepadButton, {buttonName}: {buttonName: string}) => void} callback - The function to be called when the button is pressed.
+ * @param {(gamepad: Gamepad, button: GamepadButton, buttonName: string) => void} callback - The function to be called when the button is pressed.
  * @param {Object} [options] - Register options.
  * @param {Number} [options.gamepad] - Gamepad index. Defaults to registerting for all gamepads.
  * @param {'gamepaddown'|'gamepadup'} [options.handler='gamepaddown'] - Whether to register to the gamepaddown or gamepadup event.

--- a/src/gamepad.js
+++ b/src/gamepad.js
@@ -164,7 +164,7 @@ export function updateGamepad() {
           gamepaddownCallbacks[gamepad.index],
           gamepaddownCallbacks
         ].map(callback => {
-          callback?.[buttonName]?.(gamepad, button);
+          callback?.[buttonName]?.(gamepad, button, { buttonName });
         });
       }
       // if the button was pressed before and is now not pressed
@@ -172,7 +172,7 @@ export function updateGamepad() {
       else if (state && !pressed) {
         [gamepadupCallbacks[gamepad.index], gamepadupCallbacks].map(
           callback => {
-            callback?.[buttonName]?.(gamepad, button);
+            callback?.[buttonName]?.(gamepad, button, { buttonName });
           }
         );
       }
@@ -208,7 +208,7 @@ export function initGamepad() {
 }
 
 /**
- * Register a function to be called when a gamepad button is pressed. Takes a single button or an array of buttons. Is passed the [Gamepad](https://developer.mozilla.org/en-US/docs/Web/API/Gamepad) and the [GamepadButton](https://developer.mozilla.org/en-US/docs/Web/API/GamepadButton) that was pressed as parameters.
+ * Register a function to be called when a gamepad button is pressed. Takes a single button or an array of buttons. Is passed the [Gamepad](https://developer.mozilla.org/en-US/docs/Web/API/Gamepad) and the [GamepadButton](https://developer.mozilla.org/en-US/docs/Web/API/GamepadButton), and the buttonName that was pressed as parameters.
  *
  * When registering the function, you have the choice of registering to a specific gamepad or to all gamepads. To register to a specific gamepad, pass the desired gamepad index as the `gamepad` option. If the `gamepad` option is ommited the callback is bound to all gamepads instead of a specific one.
  *

--- a/test/unit/gamepad.spec.js
+++ b/test/unit/gamepad.spec.js
@@ -96,7 +96,8 @@ describe('gamepad', () => {
         expect(
           spy.calledWith(
             getGamepadsStub[0],
-            getGamepadsStub[0].buttons[0]
+            getGamepadsStub[0].buttons[0],
+            'south'
           )
         ).to.be.true;
       });
@@ -111,7 +112,8 @@ describe('gamepad', () => {
         expect(
           spy.calledWith(
             getGamepadsStub[0],
-            getGamepadsStub[0].buttons[0]
+            getGamepadsStub[0].buttons[0],
+            'south'
           )
         ).to.be.true;
       });
@@ -128,7 +130,8 @@ describe('gamepad', () => {
         expect(
           spy.calledWith(
             getGamepadsStub[1],
-            getGamepadsStub[1].buttons[0]
+            getGamepadsStub[1].buttons[0],
+            'south'
           )
         ).to.be.true;
       });
@@ -169,7 +172,8 @@ describe('gamepad', () => {
           expect(
             spy.calledWith(
               getGamepadsStub[3],
-              getGamepadsStub[3].buttons[3]
+              getGamepadsStub[3].buttons[3],
+              'north'
             )
           ).to.be.true;
         });
@@ -206,7 +210,8 @@ describe('gamepad', () => {
         expect(
           spy.calledWith(
             getGamepadsStub[0],
-            getGamepadsStub[0].buttons[0]
+            getGamepadsStub[0].buttons[0],
+            'south'
           )
         ).to.be.true;
       });
@@ -228,7 +233,8 @@ describe('gamepad', () => {
         expect(
           spy.calledWith(
             getGamepadsStub[0],
-            getGamepadsStub[0].buttons[0]
+            getGamepadsStub[0].buttons[0],
+            'south'
           )
         ).to.be.true;
       });
@@ -250,7 +256,8 @@ describe('gamepad', () => {
         expect(
           spy.calledWith(
             getGamepadsStub[1],
-            getGamepadsStub[1].buttons[0]
+            getGamepadsStub[1].buttons[0],
+            'south'
           )
         ).to.be.true;
       });


### PR DESCRIPTION
I have a scenario where I want to register the same listener for several gamepad buttons. I also want to know which button was pressed, which makes it easier to register 1 event listener, and remove 1 event listener (instead of creating multiple listeners)

AS-IS

It's difficult to make a decision to know which button was pressed inside the callback in `onGamepad`

We have to write code like this, but it only works for one key, not an array of keys

```js

onGamepad('south', onPlayerInput.bind({buttonName:'south'})); // not so pretty, and can be difficult to use correctly.

function onPlayerInput(...args){
  console.log('buttonName', this.buttonName});
}

// alternatively
onGamepad('south', (...args) => onPlayerInput(...args,{buttonName:'south'}));


```


TO-BE

Receive the `buttonName` as the third parameter (inside an object for extra flexibility if we want to add more params in the future,) making it easier to know which button initiated the callback.

```js

const onPlayerInput = (gamepad, button, buttonName) => {
  console.log('buttonName', buttonName);
  if(buttonName === 'south') {
    // do something special
  }
}

initControls() {
  onGamepad(['south, north'], onPlayerInput);
}

```

## TODO

- [x] Add additional typings to kontra.d.ts?
    - I don't know if kontra.d.ts is autogenerated or not 