### PR TITLE
fix: allow objects to be created before init

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -92,3 +92,8 @@ export function init(canvas, { contextless = false } = {}) {
 
   return { canvas: canvasEl, context };
 }
+
+// expose for testing
+export function _reset() {
+  canvasEl = context = undefined;
+}

--- a/src/gameLoop.js
+++ b/src/gameLoop.js
@@ -1,5 +1,5 @@
 import { noop } from './utils.js';
-import { emit } from './events.js';
+import { emit, on } from './events.js';
 import { getContext } from './core.js';
 
 /**
@@ -87,6 +87,10 @@ export default function GameLoop({
     });
   }
 
+  on('init', () => {
+    loop.context ??= getContext();
+  });
+
   /**
    * Called every frame of the game loop.
    */
@@ -115,7 +119,7 @@ export default function GameLoop({
       accumulator -= delta;
     }
 
-    clearFn(context);
+    clearFn(loop.context);
     loop.render();
   }
 
@@ -158,6 +162,14 @@ export default function GameLoop({
      * @property {Boolean} isStopped
      */
     isStopped: true,
+
+    /**
+     * The context the game loop will clear. Defaults to [core.getContext()](api/core#getCcontext).
+     *
+     * @memberof GameLoop
+     * @property {CanvasRenderingContext2D} context
+     */
+    context,
 
     /**
      * Start the game loop.

--- a/src/gameObject.js
+++ b/src/gameObject.js
@@ -1,5 +1,6 @@
 import { getContext } from './core.js';
 import Updatable from './updatable.js';
+import { on } from './events.js';
 import { rotatePoint, clamp } from './helpers.js';
 import { noop, removeFromArray } from './utils.js';
 
@@ -230,6 +231,10 @@ class GameObject extends Updatable {
 
     // uf = update function
     this._uf = update;
+
+    on('init', () => {
+      this.context ??= getContext();
+    });
   }
 
   /**

--- a/src/scene.js
+++ b/src/scene.js
@@ -149,6 +149,13 @@ class Scene {
 
     this.add(objects);
 
+    /**
+     * The camera object which is used as the focal point for the scene. Defaults to to the size of the canvas with a focal point  at its center. The scene will not render objects that are outside the bounds of the camera.
+     *
+     * Additionally, the camera can be used to [lookAt](api/scene#lookAt) an object which will center the camera to that object. This allows you to zoom the scene in and out while the camera remains centered on the object.
+     * @memberof Scene
+     * @property {GameObject} camera
+     */
     this.camera = GameObject({
       context,
       anchor: { x: 0.5, y: 0.5 },
@@ -169,13 +176,6 @@ class Scene {
 
       addToDom(section, canvas);
 
-      /**
-       * The camera object which is used as the focal point for the scene. Defaults to to the size of the canvas with a focal point  at its center. The scene will not render objects that are outside the bounds of the camera.
-       *
-       * Additionally, the camera can be used to [lookAt](api/scene#lookAt) an object which will center the camera to that object. This allows you to zoom the scene in and out while the camera remains centered on the object.
-       * @memberof Scene
-       * @property {GameObject} camera
-       */
       let { width, height } = canvas;
       let x = width / 2;
       let y = height / 2;

--- a/src/scene.js
+++ b/src/scene.js
@@ -1,5 +1,6 @@
 import { getContext } from './core.js';
 import GameObject from './gameObject.js';
+import { on } from './events.js';
 import { srOnlyStyle, addToDom, removeFromArray } from './utils.js';
 import { collides } from './helpers.js';
 
@@ -134,18 +135,6 @@ class Scene {
   }) {
     // o = objects
     this._o = [];
-    let canvas = context.canvas;
-
-    // create an accessible DOM node for screen readers (do this first
-    // so we can move DOM nodes in add())
-    // dn = dom node
-    let section = (this._dn = document.createElement('section'));
-    section.tabIndex = -1;
-    section.style = srOnlyStyle;
-    section.id = id;
-    section.setAttribute('aria-label', name);
-
-    addToDom(section, canvas);
 
     // add all properties to the object, overriding any defaults
     Object.assign(this, {
@@ -158,29 +147,58 @@ class Scene {
       ...props
     });
 
-    /**
-     * The camera object which is used as the focal point for the scene. Defaults to to the size of the canvas with a focal point  at its center. The scene will not render objects that are outside the bounds of the camera.
-     *
-     * Additionally, the camera can be used to [lookAt](api/scene#lookAt) an object which will center the camera to that object. This allows you to zoom the scene in and out while the camera remains centered on the object.
-     * @memberof Scene
-     * @property {GameObject} camera
-     */
-    let { width, height } = canvas;
-    let x = width / 2;
-    let y = height / 2;
+    this.add(objects);
+
     this.camera = GameObject({
-      x,
-      y,
-      width,
-      height,
       context,
-      centerX: x,
-      centerY: y,
       anchor: { x: 0.5, y: 0.5 },
       render: this._rf.bind(this)
     });
 
-    this.add(objects);
+    let init = () => {
+      let canvas = this.context.canvas;
+
+      // create an accessible DOM node for screen readers
+      // (do this first so we can move DOM nodes in add())
+      // dn = dom node
+      let section = (this._dn = document.createElement('section'));
+      section.tabIndex = -1;
+      section.style = srOnlyStyle;
+      section.id = id;
+      section.setAttribute('aria-label', name);
+
+      addToDom(section, canvas);
+
+      /**
+       * The camera object which is used as the focal point for the scene. Defaults to to the size of the canvas with a focal point  at its center. The scene will not render objects that are outside the bounds of the camera.
+       *
+       * Additionally, the camera can be used to [lookAt](api/scene#lookAt) an object which will center the camera to that object. This allows you to zoom the scene in and out while the camera remains centered on the object.
+       * @memberof Scene
+       * @property {GameObject} camera
+       */
+      let { width, height } = canvas;
+      let x = width / 2;
+      let y = height / 2;
+      Object.assign(this.camera, {
+        x,
+        y,
+        width,
+        height,
+        centerX: x,
+        centerY: y,
+      });
+    }
+
+    if (this.context) {
+      init();
+    }
+
+    on('init', () => {
+      this.context ??= getContext();
+      if (!this._dn) {
+        init();
+      }
+    });
   }
 
   set objects(value) {
@@ -269,7 +287,7 @@ class Scene {
    * @function destroy
    */
   destroy() {
-    this._dn.remove();
+    this._dn?.remove();
     this._o.map(object => object.destroy && object.destroy());
   }
 

--- a/src/text.js
+++ b/src/text.js
@@ -1,9 +1,12 @@
 import { GameObjectClass } from './gameObject.js';
+import { on } from './events.js';
 import { getContext } from './core.js';
 
 let fontSizeRegex = /(\d+)(\w+)/;
 
 function parseFont(font) {
+  if (!font) return { computed: 0 };
+
   let match = font.match(fontSizeRegex);
 
   // coerce string to number
@@ -91,7 +94,7 @@ class Text extends GameObjectClass {
      * @memberof Text
      * @property {String} font
      */
-    font = getContext().font,
+    font = getContext()?.font,
 
     /**
      * The color of the text.
@@ -113,7 +116,14 @@ class Text extends GameObjectClass {
     });
 
     // p = prerender
-    this._p();
+    if (this.context) {
+      this._p();
+    }
+
+    on('init', () => {
+      this.font ??= getContext().font;
+      this._p();
+    });
   }
 
   // keep width and height getters/settings so we can set _w and _h

--- a/src/tileEngine.js
+++ b/src/tileEngine.js
@@ -1,4 +1,5 @@
 import { getCanvas, getContext } from './core.js';
+import { on } from './events.js';
 import { clamp, getWorldRect } from './helpers.js';
 import { removeFromArray } from './utils.js';
 
@@ -217,7 +218,14 @@ class TileEngine {
     });
 
     // p = prerender
-    this._p();
+    if (this.context) {
+      this._p();
+    }
+
+    on('init', () => {
+      this.context ??= getContext();
+      this._p();
+    });
   }
 
   // @ifdef TILEENGINE_CAMERA

--- a/test/integration/core.spec.js
+++ b/test/integration/core.spec.js
@@ -1,0 +1,64 @@
+import Sprite from '../../src/sprite.js';
+import TileEngine from '../../src/tileEngine.js';
+import GameLoop from '../../src/gameLoop.js';
+import Text from '../../src/text.js';
+import Scene from '../../src/scene.js';
+import { _reset, init } from '../../src/core.js';
+import { noop } from '../../src/utils.js';
+
+describe('core integration', () => {
+  beforeEach(() => {
+    _reset();
+  });
+
+  it('should allow calling init after creating objects', () => {
+    let sprite = Sprite({
+      x: 10,
+      y: 20,
+      width: 10,
+      height: 20,
+      color: 'red'
+    });
+    let loop = GameLoop({
+      update: noop,
+      render: noop
+    });
+    let text = Text({ text: 'Hello World' });
+    let tileEngine = TileEngine({
+      tilewidth: 10,
+      tileheight: 10,
+      width: 50,
+      height: 50,
+      tilesets: [
+        {
+          image: new Image()
+        }
+      ],
+      layers: [
+        {
+          name: 'test',
+          data: [0, 0, 1, 0, 0]
+        }
+      ]
+    });
+
+    let scene = Scene({
+      id: 'myId',
+      objects: [sprite, text]
+    });
+
+    expect(() => scene.lookAt(sprite)).to.not.throw();
+
+    let canvas = document.createElement('canvas');
+    canvas.width = canvas.height = 600;
+    init(canvas);
+
+    expect(() => sprite.render()).to.not.throw();
+    expect(() => text.render()).to.not.throw();
+    expect(() => tileEngine.render()).to.not.throw();
+    expect(() => scene.render()).to.not.throw();
+
+    loop._last = performance.now() - (1e3 / 60) * 2.5;
+    expect(() => loop._frame()).to.not.throw();
+  });
+});

--- a/test/setup.js
+++ b/test/setup.js
@@ -1,4 +1,7 @@
-import { init } from '../src/core.js';
+// permutations script prepends this file with the test file
+// so we need to rename this import so other files that import
+// it don't import by the same name
+import { init as initCore } from '../src/core.js';
 
 // ensure canvas exists before each test
 function setup() {
@@ -6,7 +9,7 @@ function setup() {
   canvas.id = 'mainCanvas';
   canvas.width = canvas.height = 600;
   document.body.appendChild(canvas);
-  init(canvas);
+  initCore(canvas);
 }
 
 beforeEach(() => {

--- a/test/unit/gameLoop.spec.js
+++ b/test/unit/gameLoop.spec.js
@@ -1,5 +1,5 @@
 import GameLoop from '../../src/gameLoop.js';
-import { getContext } from '../../src/core.js';
+import { _reset, init, getContext } from '../../src/core.js';
 import { on } from '../../src/events.js';
 import { noop } from '../../src/utils.js';
 import { simulateEvent } from '../utils.js';
@@ -24,6 +24,37 @@ describe('gameLoop', () => {
       }
 
       expect(func).to.throw();
+    });
+
+    it('should set context if kontra.init is called after created', () => {
+      _reset();
+
+      let loop = GameLoop({
+        render: noop
+      });
+
+      expect(loop.context).to.be.undefined;
+
+      let canvas = document.createElement('canvas');
+      canvas.width = canvas.height = 600;
+      init(canvas);
+
+      expect(loop.context).to.equal(canvas.getContext('2d'));
+    });
+
+    it('should not override context when set if kontra.init is called after created', () => {
+      _reset();
+
+      let loop = GameLoop({
+        render: noop,
+        context: true
+      });
+
+      let canvas = document.createElement('canvas');
+      canvas.width = canvas.height = 600;
+      init(canvas);
+
+      expect(loop.context).to.equal(true);
     });
   });
 

--- a/test/unit/gameObject.spec.js
+++ b/test/unit/gameObject.spec.js
@@ -1,5 +1,5 @@
 import GameObject, { GameObjectClass } from '../../src/gameObject.js';
-import { getContext } from '../../src/core.js';
+import { _reset, init, getContext } from '../../src/core.js';
 import { noop } from '../../src/utils.js';
 import { degToRad } from '../../src/helpers.js';
 
@@ -82,6 +82,32 @@ describe(
         let obj = new MyClass();
         expect(obj.width).to.equal(20);
         expect(obj.height).to.equal(30);
+      });
+
+      it('should set context if kontra.init is called after created', () => {
+        _reset();
+
+        gameObject = GameObject();
+
+        expect(gameObject.context).to.be.undefined;
+
+        let canvas = document.createElement('canvas');
+        canvas.width = canvas.height = 600;
+        init(canvas);
+
+        expect(gameObject.context).to.equal(canvas.getContext('2d'));
+      });
+
+      it('should not override context when set if kontra.init is called after created', () => {
+        _reset();
+
+        gameObject = GameObject({ context: true });
+
+        let canvas = document.createElement('canvas');
+        canvas.width = canvas.height = 600;
+        init(canvas);
+
+        expect(gameObject.context).to.equal(true);
       });
 
       if (testContext.GAMEOBJECT_ANCHOR) {

--- a/test/unit/scene.spec.js
+++ b/test/unit/scene.spec.js
@@ -1,5 +1,5 @@
 import Scene, { SceneClass } from '../../src/scene.js';
-import { getContext, getCanvas } from '../../src/core.js';
+import { _reset, init, getContext, getCanvas } from '../../src/core.js';
 import { noop, srOnlyStyle } from '../../src/utils.js';
 import { collides } from '../../src/helpers.js';
 
@@ -128,6 +128,65 @@ describe('scene', () => {
       expect(scene.camera.width).to.equal(canvas.width);
       expect(scene.camera.height).to.equal(canvas.height);
       expect(scene.camera.anchor).to.deep.equal({ x: 0.5, y: 0.5 });
+    });
+
+    it('should not set dom node or camera if context is not set', () => {
+      _reset();
+
+      scene = Scene({
+        id: 'myId'
+      });
+
+      expect(scene._dn).to.not.exist;
+      expect(scene.camera.centerX).to.not.exist;
+    });
+
+    it('should set context if kontra.init is called after created', () => {
+      _reset();
+
+      scene = Scene({
+        id: 'myId'
+      });
+
+      expect(scene.context).to.be.undefined;
+
+      let canvas = document.createElement('canvas');
+      canvas.width = canvas.height = 600;
+      init(canvas);
+
+      expect(scene.context).to.equal(canvas.getContext('2d'));
+    });
+
+    it('should not override context when set if kontra.init is called after created', () => {
+      let context = getContext();
+
+      _reset();
+
+      scene = Scene({
+        id: 'myId',
+        context
+      });
+
+      let canvas = document.createElement('canvas');
+      canvas.width = canvas.height = 600;
+      init(canvas);
+
+      expect(scene.context).to.equal(context);
+    });
+
+    it('should set dom node and camera if kontra.init is called after created', () => {
+      _reset();
+
+      scene = Scene({
+        id: 'myId'
+      });
+
+      let canvas = document.createElement('canvas');
+      canvas.width = canvas.height = 600;
+      init(canvas);
+
+      expect(scene._dn).to.exist;
+      expect(scene.camera.centerX).to.exist;
     });
   });
 

--- a/test/unit/text.spec.js
+++ b/test/unit/text.spec.js
@@ -1,5 +1,5 @@
 import Text, { TextClass } from '../../src/text.js';
-import { getContext } from '../../src/core.js';
+import { _reset, init, getContext } from '../../src/core.js';
 
 // test-context:start
 let testContext = {
@@ -93,6 +93,56 @@ describe(
         text.width = 100;
 
         expect(text._d).to.be.true;
+      });
+
+      it('should not call prerender if context is not set', () => {
+        _reset();
+
+        let text = Text({ text: '' });
+
+        expect(text._s).to.not.exist;
+      });
+
+      it('should set font if kontra.init is called after created', () => {
+        _reset();
+
+        let text = Text({ text: '' });
+
+        expect(text.font).to.be.undefined;
+
+        let canvas = document.createElement('canvas');
+        canvas.width = canvas.height = 600;
+        let context = canvas.getContext('2d');
+        context.font = '32px Arial';
+        init(canvas);
+
+        expect(text.font).to.equal('32px Arial');
+      });
+
+      it('should not override font when set if kontra.init is called after created', () => {
+        _reset();
+
+        let text = Text({ text: '', font: '42px Arial' });
+
+        let canvas = document.createElement('canvas');
+        canvas.width = canvas.height = 600;
+        let context = canvas.getContext('2d');
+        context.font = '32px Arial';
+        init(canvas);
+
+        expect(text.font).to.equal('42px Arial');
+      });
+
+      it('should call prerender if kontra.init is called after created', () => {
+        _reset();
+
+        let text = Text({ text: '' });
+
+        let canvas = document.createElement('canvas');
+        canvas.width = canvas.height = 600;
+        init(canvas);
+
+        expect(text._s).to.exist;
       });
     });
 

--- a/test/unit/tileEngine.spec.js
+++ b/test/unit/tileEngine.spec.js
@@ -1,5 +1,5 @@
 import TileEngine, { TileEngineClass } from '../../src/tileEngine.js';
-import { getContext } from '../../src/core.js';
+import { _reset, init, getContext } from '../../src/core.js';
 import { noop } from '../../src/utils.js';
 
 // test-context:start
@@ -52,6 +52,121 @@ describe(
         expect(tileEngine.layers).to.equal(data.layers);
         expect(tileEngine.mapwidth).to.equal(500);
         expect(tileEngine.mapheight).to.equal(500);
+      });
+
+      it('should not error if context is not set', () => {
+        _reset();
+
+        function fn() {
+          TileEngine({
+            tilewidth: 10,
+            tileheight: 10,
+            width: 50,
+            height: 50,
+            tilesets: [
+              {
+                image: new Image()
+              }
+            ],
+            layers: [
+              {
+                name: 'test',
+                data: [0, 0, 1, 0, 0]
+              }
+            ]
+          });
+        }
+
+        expect(fn).to.not.throw();
+      });
+
+      it('should set context if kontra.init is called after created', () => {
+        _reset();
+
+        let tileEngine = TileEngine({
+          tilewidth: 10,
+          tileheight: 10,
+          width: 50,
+          height: 50,
+          tilesets: [
+            {
+              image: new Image()
+            }
+          ],
+          layers: [
+            {
+              name: 'test',
+              data: [0, 0, 1, 0, 0]
+            }
+          ]
+        });
+
+        expect(tileEngine.context).to.be.undefined;
+
+        let canvas = document.createElement('canvas');
+        canvas.width = canvas.height = 600;
+        init(canvas);
+
+        expect(tileEngine.context).to.equal(canvas.getContext('2d'));
+      });
+
+      it('should not override context when set if kontra.init is called after created', () => {
+        _reset();
+
+        let tileEngine = TileEngine({
+          tilewidth: 10,
+          tileheight: 10,
+          width: 50,
+          height: 50,
+          tilesets: [
+            {
+              image: new Image()
+            }
+          ],
+          layers: [
+            {
+              name: 'test',
+              data: [0, 0, 1, 0, 0]
+            }
+          ]
+        });
+        tileEngine.context = true;
+
+        let canvas = document.createElement('canvas');
+        canvas.width = canvas.height = 600;
+        init(canvas);
+
+        expect(tileEngine.context).to.equal(true);
+      });
+
+      it('should call prerender if kontra.init is called after created', () => {
+        _reset();
+
+        let tileEngine = TileEngine({
+          tilewidth: 10,
+          tileheight: 10,
+          width: 50,
+          height: 50,
+          tilesets: [
+            {
+              image: new Image()
+            }
+          ],
+          layers: [
+            {
+              name: 'test',
+              data: [0, 0, 1, 0, 0]
+            }
+          ]
+        });
+
+        sinon.stub(tileEngine, '_p').callsFake(noop);
+
+        let canvas = document.createElement('canvas');
+        canvas.width = canvas.height = 600;
+        init(canvas);
+
+        expect(tileEngine._p.called).to.be.true;
       });
     });
 


### PR DESCRIPTION
Use the `init` emit from core to initialize all the `context` properties of various objects.

Closes #318