### PR TITLE
chore: add version comment to kontra files, version doc service worker

### DIFF
--- a/docs/service-worker.js
+++ b/docs/service-worker.js
@@ -18,7 +18,7 @@ const filesToCache = [
   `${prefix}/assets/styles.css`
 ];
 
-const staticCacheName = 'kontra-docs-v3';
+const staticCacheName = 'kontra-docs-v8.0.0';
 
 // cache the application shell
 self.addEventListener('install', event => {

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -6,6 +6,7 @@ const plumber = require('gulp-plumber');
 const preprocess = require('gulp-preprocess');
 const rollup = require('@rollup/stream');
 const source = require('vinyl-source-stream');
+const packageJson = require('./package.json');
 require('./tasks/docs.js');
 require('./tasks/typescript.js');
 
@@ -41,13 +42,19 @@ const context = {
   // DEBUG and VISUAL_DEBUG are turned off
 };
 
+const headerComment = `/**
+ * @preserve
+ * Kontra.js v${packageJson.version}
+ */`;
+
 function buildIife() {
   return rollup({
     input: './src/kontra.defaults.js',
     output: {
       format: 'iife',
       name: 'kontra',
-      strict: false
+      strict: false,
+      banner: headerComment
     }
   })
     .pipe(source('kontra.js'))
@@ -60,7 +67,8 @@ function buildModule() {
     input: './src/kontra.js',
     output: {
       format: 'es',
-      strict: false
+      strict: false,
+      banner: headerComment
     }
   })
     .pipe(source('kontra.mjs'))

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -6,7 +6,7 @@ const plumber = require('gulp-plumber');
 const preprocess = require('gulp-preprocess');
 const rollup = require('@rollup/stream');
 const source = require('vinyl-source-stream');
-const packageJson = require('./package.json');
+const pkg = require('./package.json');
 require('./tasks/docs.js');
 require('./tasks/typescript.js');
 
@@ -44,7 +44,7 @@ const context = {
 
 const headerComment = `/**
  * @preserve
- * Kontra.js v${packageJson.version}
+ * Kontra.js v${pkg.version}
  */`;
 
 function buildIife() {

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,7 @@
         "gulp-plumber": "^1.2.1",
         "gulp-preprocess": "git+https://github.com/straker/gulp-preprocess.git",
         "gulp-rename": "^2.0.0",
+        "gulp-replace": "^1.1.3",
         "gulp-size": "^4.0.1",
         "gulp-terser": "^2.1.0",
         "http-server": "^14.0.0",
@@ -712,6 +713,12 @@
       "integrity": "sha512-vt+kDhq/M2ayberEtJcIN/hxXy1Pk+59g2FV/ZQceeaTyCtCucjL2Q7FXlFjtWn4n15KCr1NE2lNNFhp0lEThw==",
       "dev": true
     },
+    "node_modules/@types/expect": {
+      "version": "1.20.4",
+      "resolved": "https://registry.npmjs.org/@types/expect/-/expect-1.20.4.tgz",
+      "integrity": "sha512-Q5Vn3yjTDyCMV50TB6VRIbQNxSE4OmZR86VSbGaNpfUolm0iePBB4KdEEHmxoY5sT2+2DIvXW0rvMDP2nHZ4Mg==",
+      "dev": true
+    },
     "node_modules/@types/node": {
       "version": "18.6.4",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-18.6.4.tgz",
@@ -723,6 +730,16 @@
       "resolved": "https://registry.npmjs.org/@types/parse-json/-/parse-json-4.0.0.tgz",
       "integrity": "sha512-//oorEZjL6sbPcKUaCdIGlIUeH26mgzimjBB77G6XRgnDl/L5wOnpyBGRe/Mmf5CVW3PwEBE1NjiMZ/ssFh4wA==",
       "dev": true
+    },
+    "node_modules/@types/vinyl": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@types/vinyl/-/vinyl-2.0.7.tgz",
+      "integrity": "sha512-4UqPv+2567NhMQuMLdKAyK4yzrfCqwaTt6bLhHEs8PFcxbHILsrxaY63n4wgE/BRLDWDQeI+WcTmkXKExh9hQg==",
+      "dev": true,
+      "dependencies": {
+        "@types/expect": "^1.20.4",
+        "@types/node": "*"
+      }
     },
     "node_modules/@ungap/promise-all-settled": {
       "version": "1.1.2",
@@ -1475,6 +1492,18 @@
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/binaryextensions": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/binaryextensions/-/binaryextensions-2.3.0.tgz",
+      "integrity": "sha512-nAihlQsYGyc5Bwq6+EsubvANYGExeJKHDO3RjnvwU042fawQTQfM3Kxn7IHUXQOz4bzfwsGYYHGSvXyW4zOGLg==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.8"
+      },
+      "funding": {
+        "url": "https://bevry.me/fund"
       }
     },
     "node_modules/bindings": {
@@ -4141,6 +4170,28 @@
         "node": ">=4"
       }
     },
+    "node_modules/gulp-replace": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/gulp-replace/-/gulp-replace-1.1.3.tgz",
+      "integrity": "sha512-HcPHpWY4XdF8zxYkDODHnG2+7a3nD/Y8Mfu3aBgMiCFDW3X2GiOKXllsAmILcxe3KZT2BXoN18WrpEFm48KfLQ==",
+      "dev": true,
+      "dependencies": {
+        "@types/node": "^14.14.41",
+        "@types/vinyl": "^2.0.4",
+        "istextorbinary": "^3.0.0",
+        "replacestream": "^4.0.3",
+        "yargs-parser": ">=5.0.0-security.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/gulp-replace/node_modules/@types/node": {
+      "version": "14.18.34",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.34.tgz",
+      "integrity": "sha512-hcU9AIQVHmPnmjRK+XUUYlILlr9pQrsqSrwov/JK1pnf3GTQowVBhx54FbvM0AU/VXGH4i3+vgXS5EguR7fysA==",
+      "dev": true
+    },
     "node_modules/gulp-size": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/gulp-size/-/gulp-size-4.0.1.tgz",
@@ -5133,6 +5184,22 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/istextorbinary": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/istextorbinary/-/istextorbinary-3.3.0.tgz",
+      "integrity": "sha512-Tvq1W6NAcZeJ8op+Hq7tdZ434rqnMx4CCZ7H0ff83uEloDvVbqAwaMTZcafKGJT0VHkYzuXUiCY4hlXQg6WfoQ==",
+      "dev": true,
+      "dependencies": {
+        "binaryextensions": "^2.2.0",
+        "textextensions": "^3.2.0"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://bevry.me/fund"
       }
     },
     "node_modules/js-tokens": {
@@ -8426,6 +8493,26 @@
         "node": ">= 0.10"
       }
     },
+    "node_modules/replacestream": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/replacestream/-/replacestream-4.0.3.tgz",
+      "integrity": "sha512-AC0FiLS352pBBiZhd4VXB1Ab/lh0lEgpP+GGvZqbQh8a5cmXVoTe5EX/YeTFArnp4SRGTHh1qCHu9lGs1qG8sA==",
+      "dev": true,
+      "dependencies": {
+        "escape-string-regexp": "^1.0.3",
+        "object-assign": "^4.0.1",
+        "readable-stream": "^2.0.2"
+      }
+    },
+    "node_modules/replacestream/node_modules/escape-string-regexp": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
     "node_modules/request": {
       "version": "2.88.2",
       "resolved": "https://registry.npmjs.org/request/-/request-2.88.2.tgz",
@@ -9405,6 +9492,18 @@
       "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
       "integrity": "sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==",
       "dev": true
+    },
+    "node_modules/textextensions": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/textextensions/-/textextensions-3.3.0.tgz",
+      "integrity": "sha512-mk82dS8eRABNbeVJrEiN5/UMSCliINAuz8mkUwH4SwslkNP//gbEzlWNS5au0z5Dpx40SQxzqZevZkn+WYJ9Dw==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://bevry.me/fund"
+      }
     },
     "node_modules/through": {
       "version": "2.3.8",
@@ -11021,6 +11120,12 @@
       "integrity": "sha512-vt+kDhq/M2ayberEtJcIN/hxXy1Pk+59g2FV/ZQceeaTyCtCucjL2Q7FXlFjtWn4n15KCr1NE2lNNFhp0lEThw==",
       "dev": true
     },
+    "@types/expect": {
+      "version": "1.20.4",
+      "resolved": "https://registry.npmjs.org/@types/expect/-/expect-1.20.4.tgz",
+      "integrity": "sha512-Q5Vn3yjTDyCMV50TB6VRIbQNxSE4OmZR86VSbGaNpfUolm0iePBB4KdEEHmxoY5sT2+2DIvXW0rvMDP2nHZ4Mg==",
+      "dev": true
+    },
     "@types/node": {
       "version": "18.6.4",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-18.6.4.tgz",
@@ -11032,6 +11137,16 @@
       "resolved": "https://registry.npmjs.org/@types/parse-json/-/parse-json-4.0.0.tgz",
       "integrity": "sha512-//oorEZjL6sbPcKUaCdIGlIUeH26mgzimjBB77G6XRgnDl/L5wOnpyBGRe/Mmf5CVW3PwEBE1NjiMZ/ssFh4wA==",
       "dev": true
+    },
+    "@types/vinyl": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@types/vinyl/-/vinyl-2.0.7.tgz",
+      "integrity": "sha512-4UqPv+2567NhMQuMLdKAyK4yzrfCqwaTt6bLhHEs8PFcxbHILsrxaY63n4wgE/BRLDWDQeI+WcTmkXKExh9hQg==",
+      "dev": true,
+      "requires": {
+        "@types/expect": "^1.20.4",
+        "@types/node": "*"
+      }
     },
     "@ungap/promise-all-settled": {
       "version": "1.1.2",
@@ -11608,6 +11723,12 @@
       "version": "1.13.1",
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.13.1.tgz",
       "integrity": "sha512-Un7MIEDdUC5gNpcGDV97op1Ywk748MpHcFTHoYs6qnj1Z3j7I53VG3nwZhKzoBZmbdRNnb6WRdFlwl7tSDuZGw==",
+      "dev": true
+    },
+    "binaryextensions": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/binaryextensions/-/binaryextensions-2.3.0.tgz",
+      "integrity": "sha512-nAihlQsYGyc5Bwq6+EsubvANYGExeJKHDO3RjnvwU042fawQTQfM3Kxn7IHUXQOz4bzfwsGYYHGSvXyW4zOGLg==",
       "dev": true
     },
     "bindings": {
@@ -13717,6 +13838,27 @@
       "integrity": "sha512-97Vba4KBzbYmR5VBs9mWmK+HwIf5mj+/zioxfZhOKeXtx5ZjBk57KFlePf5nxq9QsTtFl0ejnHE3zTC9MHXqyQ==",
       "dev": true
     },
+    "gulp-replace": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/gulp-replace/-/gulp-replace-1.1.3.tgz",
+      "integrity": "sha512-HcPHpWY4XdF8zxYkDODHnG2+7a3nD/Y8Mfu3aBgMiCFDW3X2GiOKXllsAmILcxe3KZT2BXoN18WrpEFm48KfLQ==",
+      "dev": true,
+      "requires": {
+        "@types/node": "^14.14.41",
+        "@types/vinyl": "^2.0.4",
+        "istextorbinary": "^3.0.0",
+        "replacestream": "^4.0.3",
+        "yargs-parser": ">=5.0.0-security.0"
+      },
+      "dependencies": {
+        "@types/node": {
+          "version": "14.18.34",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.34.tgz",
+          "integrity": "sha512-hcU9AIQVHmPnmjRK+XUUYlILlr9pQrsqSrwov/JK1pnf3GTQowVBhx54FbvM0AU/VXGH4i3+vgXS5EguR7fysA==",
+          "dev": true
+        }
+      }
+    },
     "gulp-size": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/gulp-size/-/gulp-size-4.0.1.tgz",
@@ -14462,6 +14604,16 @@
       "requires": {
         "html-escaper": "^2.0.0",
         "istanbul-lib-report": "^3.0.0"
+      }
+    },
+    "istextorbinary": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/istextorbinary/-/istextorbinary-3.3.0.tgz",
+      "integrity": "sha512-Tvq1W6NAcZeJ8op+Hq7tdZ434rqnMx4CCZ7H0ff83uEloDvVbqAwaMTZcafKGJT0VHkYzuXUiCY4hlXQg6WfoQ==",
+      "dev": true,
+      "requires": {
+        "binaryextensions": "^2.2.0",
+        "textextensions": "^3.2.0"
       }
     },
     "js-tokens": {
@@ -16988,6 +17140,25 @@
         "remove-trailing-separator": "^1.1.0"
       }
     },
+    "replacestream": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/replacestream/-/replacestream-4.0.3.tgz",
+      "integrity": "sha512-AC0FiLS352pBBiZhd4VXB1Ab/lh0lEgpP+GGvZqbQh8a5cmXVoTe5EX/YeTFArnp4SRGTHh1qCHu9lGs1qG8sA==",
+      "dev": true,
+      "requires": {
+        "escape-string-regexp": "^1.0.3",
+        "object-assign": "^4.0.1",
+        "readable-stream": "^2.0.2"
+      },
+      "dependencies": {
+        "escape-string-regexp": {
+          "version": "1.0.5",
+          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+          "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
+          "dev": true
+        }
+      }
+    },
     "request": {
       "version": "2.88.2",
       "resolved": "https://registry.npmjs.org/request/-/request-2.88.2.tgz",
@@ -17759,6 +17930,12 @@
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
       "integrity": "sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==",
+      "dev": true
+    },
+    "textextensions": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/textextensions/-/textextensions-3.3.0.tgz",
+      "integrity": "sha512-mk82dS8eRABNbeVJrEiN5/UMSCliINAuz8mkUwH4SwslkNP//gbEzlWNS5au0z5Dpx40SQxzqZevZkn+WYJ9Dw==",
       "dev": true
     },
     "through": {

--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
     "gulp-plumber": "^1.2.1",
     "gulp-preprocess": "git+https://github.com/straker/gulp-preprocess.git",
     "gulp-rename": "^2.0.0",
+    "gulp-replace": "^1.1.3",
     "gulp-size": "^4.0.1",
     "gulp-terser": "^2.1.0",
     "http-server": "^14.0.0",

--- a/tasks/docs.js
+++ b/tasks/docs.js
@@ -1,8 +1,9 @@
 const gulp = require('gulp');
 const livingcss = require('gulp-livingcss');
+const replace = require('gulp-replace');
 const path = require('path');
 const marked = require('marked');
-const packageJson = require('../package.json');
+const pkg = require('../package.json');
 const fs = require('fs');
 const glob = require('glob');
 
@@ -359,7 +360,7 @@ let tags = {
   packageVersion: function () {
     this.block.description = this.block.description.replace(
       packageVersionRegex,
-      packageJson.version
+      pkg.version
     );
   },
 
@@ -498,7 +499,18 @@ function buildApi() {
     .pipe(gulp.dest('docs/api'));
 }
 
-gulp.task('build:docs', gulp.series(buildApi, buildPages));
+function buildServiceWorker() {
+  const staticCacheName = /kontra-docs-v([\d.]+)/;
+
+  return gulp
+    .src('docs/service-worker.js')
+    .pipe(replace(staticCacheName, (match, p1) => {
+      return match.replace(p1, pkg.version);
+    }))
+    .pipe(gulp.dest('docs'));
+}
+
+gulp.task('build:docs', gulp.series(buildApi, buildPages, buildServiceWorker));
 
 gulp.task('watch:docs', function () {
   gulp.watch(

--- a/tasks/release.sh
+++ b/tasks/release.sh
@@ -24,8 +24,8 @@ if (( $# == 0 )) || ( ! containsElement $1 "${versions[@]}" ); then
 fi
 
 printf "\n${Cyan}Releasing lib${NC}\n"
-npm run dist
 npm version $1
+npm run dist
 npm publish
 
 version=$(node -p "require('./package.json').version")


### PR DESCRIPTION
Each release will up the version of the doc cache which should effectively clear the cache for each new release.

Also added the kontra version to the files so you can easily find out what version you're using.

Closes #289