### PR TITLE
test: restore sinon in single place

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "kontra.d.ts"
   ],
   "scripts": {
-    "start": "http-server -S -C cert.pem",
+    "start": "http-server --silent -S -C cert.pem",
     "test": "karma start --single-run",
     "test:watch": "karma start",
     "test:permutations": "node test/permutations",

--- a/test/setup.js
+++ b/test/setup.js
@@ -23,4 +23,5 @@ afterEach(() => {
   document
     .querySelectorAll('[data-kontra]')
     .forEach(node => node.remove());
+  sinon.restore();
 });

--- a/test/unit/animation.spec.js
+++ b/test/unit/animation.spec.js
@@ -211,8 +211,6 @@ describe('animation', () => {
       });
 
       expect(context.drawImage.called).to.be.true;
-
-      context.drawImage.restore();
     });
 
     it('should render the spriteSheet in the middle of the animation', () => {

--- a/test/unit/gameLoop.spec.js
+++ b/test/unit/gameLoop.spec.js
@@ -73,8 +73,6 @@ describe('gameLoop', () => {
       loop.start();
 
       expect(window.requestAnimationFrame.called).to.be.true;
-
-      window.requestAnimationFrame.restore();
     });
 
     it('should unset isStopped', () => {
@@ -100,8 +98,6 @@ describe('gameLoop', () => {
       loop.stop();
 
       expect(window.cancelAnimationFrame.called).to.be.true;
-
-      window.cancelAnimationFrame.restore();
     });
 
     it('should set isStopped', () => {
@@ -210,8 +206,6 @@ describe('gameLoop', () => {
       loop._frame();
 
       expect(context.clearRect.called).to.be.true;
-
-      context.clearRect.restore();
     });
 
     it('should not clear the canvas if clearCanvas is false', () => {
@@ -227,8 +221,6 @@ describe('gameLoop', () => {
       loop._frame();
 
       expect(context.clearRect.called).to.be.false;
-
-      context.clearRect.restore();
     });
 
     it('should call clearCanvas on the passed in context', () => {

--- a/test/unit/gameObject.spec.js
+++ b/test/unit/gameObject.spec.js
@@ -24,10 +24,6 @@ describe(
       gameObject = GameObject();
     });
 
-    afterEach(() => {
-      spy && spy.restore && spy.restore();
-    });
-
     it('should export class', () => {
       expect(GameObjectClass).to.be.a('function');
     });
@@ -220,15 +216,6 @@ describe(
     // render
     // --------------------------------------------------
     describe('render', () => {
-      afterEach(() => {
-        gameObject.context.translate.restore &&
-          gameObject.context.translate.restore();
-        gameObject.context.rotate.restore &&
-          gameObject.context.rotate.restore();
-        gameObject.context.scale.restore &&
-          gameObject.context.scale.restore();
-      });
-
       it('should translate to the x and y position', () => {
         gameObject.x = 10;
         gameObject.y = 20;
@@ -378,8 +365,6 @@ describe(
           gameObject.render();
 
           expect(spy.set.calledWith(0.5)).to.be.true;
-
-          spy.set.restore();
         });
       } else {
         it('should not set the globalAlpha', () => {
@@ -394,8 +379,6 @@ describe(
           gameObject.render();
 
           expect(spy.set.called).to.be.false;
-
-          spy.set.restore();
         });
       }
 

--- a/test/unit/gamepad.spec.js
+++ b/test/unit/gamepad.spec.js
@@ -10,16 +10,10 @@ import {
 // gamepad
 // --------------------------------------------------
 describe('gamepad', () => {
-  // simulate gamepad object
-  let gamepadStub;
-
-  before(() => {
-    gamepadStub = sinon
+  beforeEach(() => {
+    sinon
       .stub(navigator, 'getGamepads')
       .returns(getGamepadsStub);
-  });
-
-  beforeEach(() => {
     gamepad.initGamepad();
 
     // reset pressed buttons before each test
@@ -28,10 +22,6 @@ describe('gamepad', () => {
     // start with 1 gamepad connected
     getGamepadsStub.length = 0;
     createGamepad();
-  });
-
-  after(() => {
-    gamepadStub.restore();
   });
 
   it('should export api', () => {
@@ -76,8 +66,6 @@ describe('gamepad', () => {
       expect(spy.calledWith('gamepaddisconnected')).to.be.true;
       expect(spy.calledWith('blur')).to.be.true;
       expect(eventCallbacks.tick.length).to.equal(num + 1);
-
-      spy.restore();
     });
   });
 

--- a/test/unit/helpers.spec.js
+++ b/test/unit/helpers.spec.js
@@ -93,7 +93,6 @@ describe('helpers', () => {
     it('should get random integer between range', () => {
       sinon.stub(Math, 'random').returns(0.25);
       expect(helpers.randInt(2, 10)).to.equal(4);
-      Math.random.restore();
     });
   });
 

--- a/test/unit/input.spec.js
+++ b/test/unit/input.spec.js
@@ -18,24 +18,15 @@ import {
 // input
 // --------------------------------------------------
 describe('input', () => {
-  let gamepadStub;
-
-  before(() => {
-    gamepadStub = sinon
+  beforeEach(() => {
+    sinon
       .stub(navigator, 'getGamepads')
       .returns(getGamepadsStub);
-  });
-
-  beforeEach(() => {
     input.initInput();
   });
 
   afterEach(() => {
     resetPointers();
-  });
-
-  after(() => {
-    gamepadStub.restore();
   });
 
   it('should export api', () => {
@@ -81,9 +72,6 @@ describe('input', () => {
       expect(eventCallbacks.touchChanged).to.exist;
       // pointer
       expect(canvasSpy.calledWith('mousedown')).to.be.true;
-
-      windowSpy.restore();
-      canvasSpy.restore();
     });
 
     it('should pass pointer options', () => {

--- a/test/unit/keyboard.spec.js
+++ b/test/unit/keyboard.spec.js
@@ -86,8 +86,6 @@ describe('keyboard', () => {
       keyboard.initKeys();
 
       expect(spy.called).to.be.true;
-
-      spy.restore();
     });
   });
 

--- a/test/unit/pointer.spec.js
+++ b/test/unit/pointer.spec.js
@@ -63,8 +63,6 @@ describe('pointer', () => {
       pointer.initPointer();
 
       expect(spy.called).to.equal(true);
-
-      spy.restore();
     });
 
     it('should return the pointer object', () => {

--- a/test/unit/scene.spec.js
+++ b/test/unit/scene.spec.js
@@ -656,8 +656,6 @@ describe('scene', () => {
       expect(spy.firstCall.calledWith(290, 290)).to.be.true;
       let calls = spy.getCalls();
       expect(calls[calls.length - 2].calledWith(290, 290)).to.be.true;
-
-      spy.restore();
     });
 
     it('should sort objects', () => {

--- a/test/unit/sprite.spec.js
+++ b/test/unit/sprite.spec.js
@@ -170,8 +170,6 @@ describe(
         sprite.render();
 
         expect(sprite.context.fillRect.called).to.be.true;
-
-        sprite.context.fillRect.restore();
       });
 
       if (testContext.SPRITE_IMAGE) {
@@ -191,8 +189,6 @@ describe(
           sprite.render();
 
           expect(sprite.context.drawImage.called).to.be.true;
-
-          sprite.context.drawImage.restore();
         });
       }
 
@@ -224,8 +220,6 @@ describe(
           sprite.render();
 
           expect(sprite.currentAnimation.render.called).to.be.true;
-
-          sprite.currentAnimation.render.restore();
         });
       }
     });

--- a/test/unit/spriteSheet.spec.js
+++ b/test/unit/spriteSheet.spec.js
@@ -51,8 +51,6 @@ describe('spriteSheet', () => {
 
       expect(SpriteSheetClass.prototype.createAnimations.called).to.be
         .true;
-
-      SpriteSheetClass.prototype.createAnimations.restore();
     });
   });
 

--- a/test/unit/text.spec.js
+++ b/test/unit/text.spec.js
@@ -349,7 +349,6 @@ describe(
         text.render(0, 0);
 
         expect(text.context.fillText.called).to.be.true;
-        text.context.fillText.restore();
       });
 
       if (testContext.TEXT_ALIGN) {
@@ -374,7 +373,6 @@ describe(
 
           expect(text.context.fillText.calledWith(text.text, 1000, 0))
             .to.be.true;
-          text.context.fillText.restore();
         });
       }
 
@@ -394,7 +392,6 @@ describe(
 
           expect(text.context.fillText.calledWith(text.text, 1000, 0))
             .to.be.true;
-          text.context.fillText.restore();
         });
       }
 
@@ -421,7 +418,6 @@ describe(
               32
             )
           ).to.be.true;
-          text.context.fillText.restore();
         });
 
         it('should account for lineHeight', () => {
@@ -443,7 +439,6 @@ describe(
               64
             )
           ).to.be.true;
-          text.context.fillText.restore();
         });
       }
 
@@ -469,7 +464,6 @@ describe(
               32
             )
           ).to.be.true;
-          text.context.fillText.restore();
         });
 
         it('should account for lineHeight', () => {
@@ -490,7 +484,6 @@ describe(
               64
             )
           ).to.be.true;
-          text.context.fillText.restore();
         });
       }
 
@@ -508,7 +501,6 @@ describe(
           text.render(0, 0);
 
           expect(text.context.strokeText.called).to.be.true;
-          text.context.strokeText.restore();
         });
 
         it('should use lineWidth', () => {
@@ -525,7 +517,6 @@ describe(
           text.render(0, 0);
 
           expect(spy.set.calledWith(2)).to.be.true;
-          spy.set.restore();
         });
       }
       else {
@@ -542,7 +533,6 @@ describe(
           text.render(0, 0);
 
           expect(text.context.strokeText.called).to.be.false;
-          text.context.strokeText.restore();
         });
       }
     });

--- a/test/unit/tileEngine.spec.js
+++ b/test/unit/tileEngine.spec.js
@@ -266,8 +266,6 @@ describe(
         tileEngine.render();
 
         expect(context.drawImage.called).to.be.true;
-
-        context.drawImage.restore();
       });
 
       it('calls prerender if the tile engine is dirty', () => {
@@ -300,8 +298,6 @@ describe(
         tileEngine.render();
 
         expect(tileEngine._p.called).to.be.true;
-
-        tileEngine._p.restore();
       });
 
       if (testContext.TILEENGINE_CAMERA) {
@@ -360,8 +356,6 @@ describe(
           tileEngine.render();
 
           expect(spy.calledWith(-50, -25)).to.be.true;
-
-          spy.restore();
         });
       } else {
         it('should not translate by the camera', () => {
@@ -390,8 +384,6 @@ describe(
           tileEngine.render();
 
           expect(spy.called).to.be.false;
-
-          spy.restore();
         });
       }
     });
@@ -719,8 +711,6 @@ describe(
             tileEngine.layerCanvases.test.height
           )
         ).to.be.true;
-
-        context.drawImage.restore();
       });
 
       if (testContext.TILEENGINE_CAMERA) {
@@ -780,8 +770,6 @@ describe(
               tileEngine.layerCanvases.test.height
             )
           ).to.be.true;
-
-          context.drawImage.restore();
         });
       }
 
@@ -813,8 +801,6 @@ describe(
         tileEngine.renderLayer('test');
 
         expect(tileEngine._r.calledOnce).to.be.true;
-
-        tileEngine._r.restore();
       });
 
       it('uses the correct tileset', () => {
@@ -890,8 +876,6 @@ describe(
           tileEngine.renderLayer('test');
 
           expect(tileEngine._r.called).to.be.true;
-
-          tileEngine._r.restore();
         });
       } else {
         it('doe snot call render if the layer is dirty', () => {
@@ -927,8 +911,6 @@ describe(
           tileEngine.renderLayer('test');
 
           expect(tileEngine._r.called).to.be.false;
-
-          tileEngine._r.restore();
         });
       }
 

--- a/test/unit/updatable.spec.js
+++ b/test/unit/updatable.spec.js
@@ -26,9 +26,6 @@ describe(
     // --------------------------------------------------
     describe('constructor', () => {
       let spy;
-      afterEach(() => {
-        spy.restore();
-      });
 
       it('should call init', () => {
         spy = sinon.spy(Updatable.prototype, 'init');


### PR DESCRIPTION
Ensure no memory leaking between tests by restoring sinon at root `afterEach` instead of individually in each test