### PR TITLE
feat(random)!: add random functions rand and getSeed. seedRand no longer returns function and accepts a number

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -42,8 +42,8 @@ module.exports = function (config) {
           lines: 95
         }
       },
-      type: 'html',
-      dir : 'coverage/'
+      dir: 'coverage/',
+      reporters: [{ type: 'html' }, { type: 'text-summary' }]
     },
     client: {
       mocha: {

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -107,61 +107,6 @@ export function movePoint(point, angle, distance) {
 }
 
 /**
- * Return a random integer between a minimum (inclusive) and maximum (inclusive) integer.
- * @see https://stackoverflow.com/a/1527820/2124254
- * @function randInt
- *
- * @param {Number} min - Min integer.
- * @param {Number} max - Max integer.
- *
- * @returns {Number} Random integer between min and max values.
- */
-export function randInt(min, max) {
-  return ((Math.random() * (max - min + 1)) | 0) + min;
-}
-
-/**
- * Create a seeded random number generator.
- *
- * ```js
- * import { seedRand } from 'kontra';
- *
- * let rand = seedRand('kontra');
- * console.log(rand());  // => always 0.33761959057301283
- * ```
- * @see https://stackoverflow.com/a/47593316/2124254
- * @see https://github.com/bryc/code/blob/master/jshash/PRNGs.md
- *
- * @function seedRand
- *
- * @param {String} str - String to seed the random number generator.
- *
- * @returns {() => Number} Seeded random number generator function.
- */
-export function seedRand(str) {
-  // based on the above references, this was the smallest code yet
-  // decent quality seed random function
-
-  // first create a suitable hash of the seed string using xfnv1a
-  // @see https://github.com/bryc/code/blob/master/jshash/PRNGs.md#addendum-a-seed-generating-functions
-  for (var i = 0, h = 2166136261 >>> 0; i < str.length; i++) {
-    h = Math.imul(h ^ str.charCodeAt(i), 16777619);
-  }
-  h += h << 13;
-  h ^= h >>> 7;
-  h += h << 3;
-  h ^= h >>> 17;
-  let seed = (h += h << 5) >>> 0;
-
-  // then return the seed function and discard the first result
-  // @see https://github.com/bryc/code/blob/master/jshash/PRNGs.md#lcg-lehmer-rng
-  let rand = () =>
-    ((2 ** 31 - 1) & (seed = Math.imul(48271, seed))) / 2 ** 31;
-  rand();
-  return rand;
-}
-
-/**
  * Linearly interpolate between two values. The function calculates the number between two values based on a percent. Great for smooth transitions.
  *
  * ```js

--- a/src/kontra.defaults.js
+++ b/src/kontra.defaults.js
@@ -38,8 +38,6 @@ import {
   angleToTarget,
   rotatePoint,
   movePoint,
-  randInt,
-  seedRand,
   lerp,
   inverseLerp,
   clamp,
@@ -74,6 +72,7 @@ import {
 } from './pointer.js';
 import Pool, { PoolClass } from './pool.js';
 import Quadtree, { QuadtreeClass } from './quadtree.js';
+import { rand, randInt, getSeed, seedRand } from './random.js';
 import Scene, { SceneClass } from './scene.js';
 import Sprite, { SpriteClass } from './sprite.js';
 import SpriteSheet, { SpriteSheetClass } from './spriteSheet.js';
@@ -132,8 +131,6 @@ let kontra = {
   angleToTarget,
   rotatePoint,
   movePoint,
-  randInt,
-  seedRand,
   lerp,
   inverseLerp,
   clamp,
@@ -171,6 +168,11 @@ let kontra = {
 
   Quadtree,
   QuadtreeClass,
+
+  rand,
+  randInt,
+  getSeed,
+  seedRand,
 
   Scene,
   SceneClass,

--- a/src/kontra.js
+++ b/src/kontra.js
@@ -41,8 +41,6 @@ export {
   angleToTarget,
   rotatePoint,
   movePoint,
-  randInt,
-  seedRand,
   lerp,
   inverseLerp,
   clamp,
@@ -77,6 +75,7 @@ export {
 } from './pointer.js';
 export { default as Pool, PoolClass } from './pool.js';
 export { default as Quadtree, QuadtreeClass } from './quadtree.js';
+export { rand, randInt, getSeed, seedRand } from './random.js';
 export { default as Scene, SceneClass } from './scene.js';
 export { default as Sprite, SpriteClass } from './sprite.js';
 export {
@@ -84,6 +83,9 @@ export {
   SpriteSheetClass
 } from './spriteSheet.js';
 export { default as Text, TextClass } from './text.js';
-export { default as TileEngine, TileEngineClass } from './tileEngine.js';
+export {
+  default as TileEngine,
+  TileEngineClass
+} from './tileEngine.js';
 export { default as Vector, VectorClass } from './vector.js';
 export { default } from './kontra.defaults.js';

--- a/src/random.js
+++ b/src/random.js
@@ -1,0 +1,95 @@
+/**
+ * A pseudo-random number generator (PRNG).
+ *
+ * @sectionName Random
+ */
+let seed = Date.now();
+
+/**
+ * Return a random number between 0 (inclusive) and 1 (exclusive).
+ * @see https://github.com/bryc/code/blob/master/jshash/PRNGs.md#splitmix32s
+ * @function rand
+ *
+ * @returns {Number} Random number between 0 and <1.
+ */
+export function rand() {
+  seed |= 0;
+  seed = (seed + 0x9e3779b9) | 0;
+  let t = seed ^ (seed >>> 16);
+  t = Math.imul(t, 0x21f0aaad);
+  t = t ^ (t >>> 15);
+  t = Math.imul(t, 0x735a2d97);
+  return ((t = t ^ (t >>> 15)) >>> 0) / 4294967296;
+}
+
+/**
+ * Return a random integer between a minimum (inclusive) and maximum (inclusive) integer.
+ *
+ * ```js
+ * import { randInt, rand } from 'kontra';
+ *
+ * // random number between 10 and 20
+ * console.log( randInt(10, 20) );
+ *
+ * // bias the result of the random integer to be closer
+ * // to the max
+ * console.log( randInt(10, 20, () => rand() ** 2) );
+ * ```
+ * @see https://stackoverflow.com/a/1527820/2124254
+ * @function randInt
+ *
+ * @param {Number} min - Min integer.
+ * @param {Number} max - Max integer.
+ * @param {() => Number} [randFn] - Function that generates a random number. Useful for [biasing the random number](https://gamedev.stackexchange.com/a/116875).
+ *
+ * @returns {Number} Random integer between min and max values.
+ */
+export function randInt(min, max, randFn = rand) {
+  return ((randFn() * (max - min + 1)) | 0) + min;
+}
+
+/**
+ * Get the current seed value of the random number generator.
+ * @function getSeed
+ *
+ * @returns {Number} The seed value.
+ */
+export function getSeed() {
+  return seed;
+}
+
+/**
+ * Initialize the random number generator with a given seed.
+ *
+ * ```js
+ * import { seedRand, rand } from 'kontra';
+ *
+ * seedRand('kontra');
+ * console.log(rand()); // => always 0.26133555523119867
+ * ```
+ * @see https://stackoverflow.com/a/47593316/2124254
+ * @see https://github.com/bryc/code/blob/master/jshash/PRNGs.md
+ *
+ * @function seedRand
+ *
+ * @param {Number|String} [value=Date.now()] - Number or string to seed the random number generator.
+ */
+export function seedRand(value = Date.now()) {
+  seed = value;
+
+  if (typeof value == 'string') {
+    // create a suitable hash of the seed string using MurmurHash3
+    // @see https://github.com/bryc/code/blob/master/jshash/PRNGs.md#addendum-a-seed-generating-functions
+    for (
+      var i = 0, h = 1779033703 ^ value.length;
+      i < value.length;
+      i++
+    ) {
+      (h = Math.imul(h ^ value.charCodeAt(i), 3432918353)),
+        (h = (h << 13) | (h >>> 19));
+    }
+    h = Math.imul(h ^ (h >>> 16), 2246822507);
+    h = Math.imul(h ^ (h >>> 13), 3266489909);
+    seed = (h ^= h >>> 16) >>> 0;
+  }
+}

--- a/src/random.js
+++ b/src/random.js
@@ -3,16 +3,17 @@
  *
  * @sectionName Random
  */
-let seed = Date.now();
+let seed;
 
 /**
  * Return a random number between 0 (inclusive) and 1 (exclusive).
- * @see https://github.com/bryc/code/blob/master/jshash/PRNGs.md#splitmix32s
+ * @see https://github.com/bryc/code/blob/master/jshash/PRNGs.md#splitmix32
  * @function rand
  *
  * @returns {Number} Random number between 0 and <1.
  */
 export function rand() {
+  seed ??= Date.now();
   seed |= 0;
   seed = (seed + 0x9e3779b9) | 0;
   let t = seed ^ (seed >>> 16);
@@ -92,4 +93,9 @@ export function seedRand(value = Date.now()) {
     h = Math.imul(h ^ (h >>> 13), 3266489909);
     seed = (h ^= h >>> 16) >>> 0;
   }
+}
+
+// export just for testing
+export function _reset() {
+  seed = null;
 }

--- a/test/setup.js
+++ b/test/setup.js
@@ -8,6 +8,7 @@ import {
 import { _reset as resetAssets } from '../src/assets.js';
 import { _reset as resetEvents } from '../src/events.js';
 import { _reset as resetGesture } from '../src/gesture.js';
+import { _reset as seedReset } from '../src/random.js';
 
 // ensure canvas exists before each test
 function setup() {
@@ -36,4 +37,5 @@ afterEach(() => {
   resetCore();
   resetEvents();
   resetGesture();
+  seedReset();
 });

--- a/test/typings/helpers.ts
+++ b/test/typings/helpers.ts
@@ -10,11 +10,6 @@ let angleToTargetSprite = kontra.angleToTarget(sourceSprite, targetSprite);
 
 let point: {x: number, y: number} = kontra.rotatePoint({x: 0, y: 0}, Math.PI);
 
-let randInt: number = kontra.randInt(10, 20);
-
-let seed: Function = kontra.seedRand('kontra');
-let rand: number = seed();
-
 let lerp: number = kontra.lerp(10, 20, 0.5);
 let inverseLerp: number = kontra.inverseLerp(10, 20, 15);
 let clamp: number = kontra.clamp(10, 20, 30);

--- a/test/typings/random.ts
+++ b/test/typings/random.ts
@@ -1,0 +1,16 @@
+import * as kontra from '../../kontra.js';
+
+let rand: number = kontra.rand();
+let randInt: number = kontra.randInt(10, 20);
+
+function randFn(): number {
+  return 12;
+}
+let randIntWithFunc: number = kontra.randInt(10, 20, randFn);
+
+let seed: number = kontra.getSeed();
+
+kontra.seedRand('kontra');
+kontra.seedRand(Date.now());
+kontra.seedRand(123489719875);
+kontra.seedRand();

--- a/test/unit/helpers.spec.js
+++ b/test/unit/helpers.spec.js
@@ -12,7 +12,6 @@ describe('helpers', () => {
     expect(helpers.angleToTarget).to.be.an('function');
     expect(helpers.rotatePoint).to.be.an('function');
     expect(helpers.movePoint).to.be.an('function');
-    expect(helpers.randInt).to.be.an('function');
     expect(helpers.lerp).to.be.an('function');
     expect(helpers.inverseLerp).to.be.an('function');
     expect(helpers.clamp).to.be.an('function');
@@ -48,8 +47,12 @@ describe('helpers', () => {
     it('should return the angle to the target', () => {
       let source = { x: 300, y: 300 };
       let target = { x: 100, y: 100 };
-      expect(helpers.angleToTarget(source, target)).to.equal(-Math.PI * 3/4);
-      expect(helpers.angleToTarget(target, source)).to.equal(Math.PI / 4);
+      expect(helpers.angleToTarget(source, target)).to.equal(
+        (-Math.PI * 3) / 4
+      );
+      expect(helpers.angleToTarget(target, source)).to.equal(
+        Math.PI / 4
+      );
     });
   });
 
@@ -72,7 +75,11 @@ describe('helpers', () => {
   describe('movePoint', () => {
     it('should return the new x and y after move', () => {
       let point = { x: 300, y: 300 };
-      let newPoint = helpers.movePoint(point, -Math.PI * 3/4, 141.421);
+      let newPoint = helpers.movePoint(
+        point,
+        (-Math.PI * 3) / 4,
+        141.421
+      );
       expect(newPoint.x).to.be.closeTo(200, 0.1);
       expect(newPoint.y).to.be.closeTo(200, 0.1);
 
@@ -83,32 +90,6 @@ describe('helpers', () => {
       newPoint = helpers.movePoint(point, Math.PI, 100);
       expect(newPoint.x).to.be.closeTo(200, 0.1);
       expect(newPoint.y).to.be.closeTo(300, 0.1);
-    });
-  });
-
-  // --------------------------------------------------
-  // randInt
-  // --------------------------------------------------
-  describe('randInt', () => {
-    it('should get random integer between range', () => {
-      sinon.stub(Math, 'random').returns(0.25);
-      expect(helpers.randInt(2, 10)).to.equal(4);
-    });
-  });
-
-  // --------------------------------------------------
-  // seedRand
-  // --------------------------------------------------
-  describe('seedRand', () => {
-    it('should seed a random number generator', () => {
-      let rand = helpers.seedRand('kontra');
-      expect(rand()).to.equal(0.33761959057301283);
-
-      for (let i = 0; i < 20; i++) {
-        rand();
-      }
-
-      expect(rand()).to.equal(0.5485938163474202);
     });
   });
 

--- a/test/unit/kontra.defaults.spec.js
+++ b/test/unit/kontra.defaults.spec.js
@@ -76,8 +76,6 @@ describe('kontra.defaults', () => {
     expect(kontra.angleToTarget).to.exist;
     expect(kontra.rotatePoint).to.exist;
     expect(kontra.movePoint).to.exist;
-    expect(kontra.randInt).to.exist;
-    expect(kontra.seedRand).to.exist;
     expect(kontra.lerp).to.exist;
     expect(kontra.inverseLerp).to.exist;
     expect(kontra.clamp).to.exist;
@@ -121,6 +119,13 @@ describe('kontra.defaults', () => {
   it('should add quadtree api and class', () => {
     expect(kontra.Quadtree).to.exist;
     expect(kontra.QuadtreeClass).to.exist;
+  });
+
+  it('should add random api', () => {
+    expect(kontra.rand).to.exist;
+    expect(kontra.randInt).to.exist;
+    expect(kontra.getSeed).to.exist;
+    expect(kontra.seedRand).to.exist;
   });
 
   it('should add scene api and class', () => {

--- a/test/unit/kontra.spec.js
+++ b/test/unit/kontra.spec.js
@@ -124,7 +124,7 @@ describe('kontra', () => {
     expect(kontraExports.QuadtreeClass).to.exist;
   });
 
-  it('should add random api', () => {
+  it('should export random api', () => {
     expect(kontraExports.rand).to.exist;
     expect(kontraExports.randInt).to.exist;
     expect(kontraExports.getSeed).to.exist;

--- a/test/unit/kontra.spec.js
+++ b/test/unit/kontra.spec.js
@@ -124,6 +124,13 @@ describe('kontra', () => {
     expect(kontraExports.QuadtreeClass).to.exist;
   });
 
+  it('should add random api', () => {
+    expect(kontraExports.rand).to.exist;
+    expect(kontraExports.randInt).to.exist;
+    expect(kontraExports.getSeed).to.exist;
+    expect(kontraExports.seedRand).to.exist;
+  });
+
   it('should export scene api and class', () => {
     expect(kontraExports.Scene).to.exist;
     expect(kontraExports.SceneClass).to.exist;

--- a/test/unit/random.spec.js
+++ b/test/unit/random.spec.js
@@ -15,8 +15,13 @@ describe('random', () => {
   // rand
   // --------------------------------------------------
   describe('rand', () => {
-    it('should get random integer between range', () => {
+    it('should get random value between 0 and <1', () => {
       expect(random.rand()).to.be.within(0, 1);
+    });
+
+    it('should work if seed has not been seeded', () => {
+      random._reset();
+      expect(random.rand).to.not.throw();
     });
   });
 
@@ -33,8 +38,7 @@ describe('random', () => {
   // seedRand
   // --------------------------------------------------
   describe('seedRand', () => {
-    it('should seed with value', () => {
-      random.seedRand(2859059487);
+    function testSeededRandom() {
       expect(random.rand()).to.equal(0.26133555523119867);
 
       for (let i = 0; i < 20; i++) {
@@ -42,30 +46,26 @@ describe('random', () => {
       }
 
       expect(random.rand()).to.equal(0.08834491996094584);
+    }
+
+    // all seed values = 2859059487
+    it('should seed with value', () => {
+      random.seedRand(2859059487);
+
+      testSeededRandom();
     });
 
     it('should seed with string', () => {
       random.seedRand('kontra');
-      expect(random.rand()).to.equal(0.26133555523119867);
 
-      for (let i = 0; i < 20; i++) {
-        random.rand();
-      }
-
-      expect(random.rand()).to.equal(0.08834491996094584);
+      testSeededRandom();
     });
 
     it('should seed with time by default', () => {
       sinon.stub(Date, 'now').returns(2859059487);
       random.seedRand();
 
-      expect(random.rand()).to.equal(0.26133555523119867);
-
-      for (let i = 0; i < 20; i++) {
-        random.rand();
-      }
-
-      expect(random.rand()).to.equal(0.08834491996094584);
+      testSeededRandom();
     });
   });
 

--- a/test/unit/random.spec.js
+++ b/test/unit/random.spec.js
@@ -1,0 +1,81 @@
+import * as random from '../../src/random.js';
+
+// --------------------------------------------------
+// random
+// --------------------------------------------------
+describe('random', () => {
+  it('should export api', () => {
+    expect(random.rand).to.be.an('function');
+    expect(random.randInt).to.be.an('function');
+    expect(random.getSeed).to.be.an('function');
+    expect(random.seedRand).to.be.an('function');
+  });
+
+  // --------------------------------------------------
+  // rand
+  // --------------------------------------------------
+  describe('rand', () => {
+    it('should get random integer between range', () => {
+      expect(random.rand()).to.be.within(0, 1);
+    });
+  });
+
+  // --------------------------------------------------
+  // randInt
+  // --------------------------------------------------
+  describe('randInt', () => {
+    it('should get random integer between range', () => {
+      expect(random.randInt(2, 10)).to.be.within(2, 10);
+    });
+  });
+
+  // --------------------------------------------------
+  // seedRand
+  // --------------------------------------------------
+  describe('seedRand', () => {
+    it('should seed with value', () => {
+      random.seedRand(2859059487);
+      expect(random.rand()).to.equal(0.26133555523119867);
+
+      for (let i = 0; i < 20; i++) {
+        random.rand();
+      }
+
+      expect(random.rand()).to.equal(0.08834491996094584);
+    });
+
+    it('should seed with string', () => {
+      random.seedRand('kontra');
+      expect(random.rand()).to.equal(0.26133555523119867);
+
+      for (let i = 0; i < 20; i++) {
+        random.rand();
+      }
+
+      expect(random.rand()).to.equal(0.08834491996094584);
+    });
+
+    it('should seed with time by default', () => {
+      sinon.stub(Date, 'now').returns(2859059487);
+      random.seedRand();
+
+      expect(random.rand()).to.equal(0.26133555523119867);
+
+      for (let i = 0; i < 20; i++) {
+        random.rand();
+      }
+
+      expect(random.rand()).to.equal(0.08834491996094584);
+    });
+  });
+
+  // --------------------------------------------------
+  // getSeed
+  // --------------------------------------------------
+  describe('getSeed', () => {
+    it('should return the seed', () => {
+      random.seedRand('kontra');
+      expect(random.getSeed()).to.equal(2859059487);
+    });
+  });
+});


### PR DESCRIPTION
Random implementation based off [Python random module](https://docs.python.org/3/library/random.html)

* Moved `randInt` and `seedRand` to own file, added `rand` and `getSeed` functions
* `seedRand` no longer returns `rand` as a function but instead just modifies the seed
* `seedRand` accepts a number (or no parameter and defaults to current time)
* updated the `seedRand` string hash function from xfnv1a to MurmurHash3 to reuse `Math.iml` for slightly better compression
* `randInt` accepts a function as 3rd parameter which can be used to pass a function that can bias the random number
* `randInt` uses `rand` by default instead of `Math.random` so is affected by seeding the PRNG
* updated the PRNG to use SplitMix32 algorithm instead of LCG (Lehmer RNG) as [LCG](https://github.com/bryc/code/blob/master/jshash/PRNGs.md#lcg-lehmer-rng) is not considered a good PRNG

Closes #379
Closes #378
Closes #377
Closes #374