### PR TITLE
Tileengine rotated

### DIFF
--- a/src/tileEngine.js
+++ b/src/tileEngine.js
@@ -10,6 +10,8 @@ import { removeFromArray } from './utils.js';
 // @see https://doc.mapeditor.org/en/stable/reference/global-tile-ids/
 let FLIPPED_HORIZONTALLY = 0x80000000;
 let FLIPPED_VERTICALLY = 0x40000000;
+// tile can be rotated also and use the bit 30 in conjunction with bit 32 or 31 to denote that
+let FLIPPED_DIAGONALLY = 0x20000000;
 // @endif
 
 /**
@@ -643,9 +645,24 @@ class TileEngine {
       // read flags
       let flippedHorizontal = tile & FLIPPED_HORIZONTALLY;
       let flippedVertical = tile & FLIPPED_VERTICALLY;
+      let turnedClockwise = 0;
+      let turnedAntiClockwise = 0;
+      let flippedDiagonally = 0;
       flipped = flippedHorizontal || flippedVertical;
 
       tile &= ~(FLIPPED_HORIZONTALLY | FLIPPED_VERTICALLY);
+
+      if (flippedHorizontal) {
+        turnedClockwise = 1;
+      } else if (flippedVertical) {
+        turnedAntiClockwise = 1;
+      }
+      
+      flippedDiagonally = tile & FLIPPED_DIAGONALLY;
+      
+      if (flippedDiagonally) {
+        tile &= ~(FLIPPED_DIAGONALLY);
+      }
       // @endif
 
       // find the tileset the tile belongs to

--- a/src/tileEngine.js
+++ b/src/tileEngine.js
@@ -642,7 +642,6 @@ class TileEngine {
 
       let flipped = 0;
       let rotated = 0;
-      let mixed = 0;
 
       // @ifdef TILEENGINE_TILED
       // read flags
@@ -669,9 +668,12 @@ class TileEngine {
         } else {
           flippedAndturnedAntiClockwise = 1;
         }
-        rotated = turnedClockwise || turnedAntiClockwise;
-        mixed =
-          flippedAndturnedClockwise || flippedAndturnedAntiClockwise;
+        rotated =
+          turnedClockwise ||
+          turnedAntiClockwise ||
+          flippedAndturnedClockwise ||
+          flippedAndturnedAntiClockwise;
+
         tile &= ~FLIPPED_DIAGONALLY;
       }
       // @endif
@@ -697,31 +699,23 @@ class TileEngine {
       let sy = ((offset / cols) | 0) * (tileheight + margin);
 
       // @ifdef TILEENGINE_TILED
-      if (mixed) {
-        context.save();
-        // Begin to apply the rotation
-        context.translate(x + tilewidth / 2, y + tileheight / 2);
-        if (flippedAndturnedAntiClockwise) {
-          // Rotate 90° anticlockwise
-          context.rotate(-Math.PI / 2); // 90° in radians
-        } else if (flippedAndturnedClockwise) {
-          // Rotate 90° clockwise
-          context.rotate(Math.PI / 2); // 90° in radians
-        }
-        // Then flip horizontally
-        context.scale(-1, 1);
-        x = -tilewidth / 2;
-        y = -tileheight / 2;
-      } else if (rotated) {
+      if (rotated) {
         context.save();
         // Translate to the center of the tile
         context.translate(x + tilewidth / 2, y + tileheight / 2);
-        if (turnedAntiClockwise) {
+        if (turnedAntiClockwise || flippedAndturnedAntiClockwise) {
           // Rotate 90° anticlockwise
           context.rotate(-Math.PI / 2); // 90° in radians
-        } else if (turnedClockwise) {
+        } else if (turnedClockwise || flippedAndturnedClockwise) {
           // Rotate 90° clockwise
           context.rotate(Math.PI / 2); // 90° in radians
+        }
+        if (
+          flippedAndturnedClockwise ||
+          flippedAndturnedAntiClockwise
+        ) {
+          // Then flip horizontally
+          context.scale(-1, 1);
         }
         x = -tilewidth / 2;
         y = -tileheight / 2;
@@ -753,7 +747,7 @@ class TileEngine {
       );
 
       // @ifdef TILEENGINE_TILED
-      if (mixed || flipped || rotated) {
+      if (flipped || rotated) {
         context.restore();
       }
       // @endif

--- a/src/tileEngine.js
+++ b/src/tileEngine.js
@@ -11,7 +11,7 @@ import { removeFromArray } from './utils.js';
 let FLIPPED_HORIZONTALLY = 0x80000000;
 let FLIPPED_VERTICALLY = 0x40000000;
 // tile can be rotated also and use the bit 30 in conjunction
-// with bit 32 or 31 to denote that
+// with bit 32 or/and 31 to denote that
 let FLIPPED_DIAGONALLY = 0x20000000;
 // @endif
 

--- a/src/tileEngine.js
+++ b/src/tileEngine.js
@@ -698,12 +698,8 @@ class TileEngine {
 
       // @ifdef TILEENGINE_TILED
       if (mixed) {
-        // Begin to flip horizontally
         context.save();
-        context.translate(x + tilewidth, y);
-        context.scale(-1, 1);
-        x = 0;
-        // Then apply the rotation
+        // Begin to apply the rotation
         context.translate(x + tilewidth / 2, y + tileheight / 2);
         if (flippedAndturnedAntiClockwise) {
           // Rotate 90° anticlockwise
@@ -712,13 +708,14 @@ class TileEngine {
           // Rotate 90° clockwise
           context.rotate(Math.PI / 2); // 90° in radians
         }
+        // Then flip horizontally
+        context.scale(-1, 1);
         x = -tilewidth / 2;
         y = -tileheight / 2;
       } else if (rotated) {
         context.save();
         // Translate to the center of the tile
         context.translate(x + tilewidth / 2, y + tileheight / 2);
-
         if (turnedAntiClockwise) {
           // Rotate 90° anticlockwise
           context.rotate(-Math.PI / 2); // 90° in radians

--- a/src/tileEngine.js
+++ b/src/tileEngine.js
@@ -655,7 +655,7 @@ class TileEngine {
       tile &= ~(FLIPPED_HORIZONTALLY | FLIPPED_VERTICALLY);
 
       flippedDiagonally = tile & FLIPPED_DIAGONALLY;
-
+      // Identify tile rotation
       if (flippedDiagonally) {
         if (flippedHorizontal) {
           turnedClockwise = 1;
@@ -686,8 +686,6 @@ class TileEngine {
       let y = ((index / width) | 0) * tileheight;
       let sx = (offset % cols) * (tilewidth + margin);
       let sy = ((offset / cols) | 0) * (tileheight + margin);
-      let destX = x;
-      let destY = y;
 
       // @ifdef TILEENGINE_TILED
       if (rotated) {
@@ -696,16 +694,14 @@ class TileEngine {
         context.translate(x + tilewidth / 2, y + tileheight / 2);
 
         if (turnedAntiClockwise) {
-          console.log('Turned Anti Clockwise');
-          // Rotate the context 90° anticlockwise
+          // Rotate 90° anticlockwise
           context.rotate(-Math.PI / 2); // 90° in radians
         } else if (turnedClockwise) {
-          console.log('Turned Clockwise');
-          // Rotate the context 90° clockwise
+          // Rotate 90° clockwise
           context.rotate(Math.PI / 2); // 90° in radians
         }
-        destX = -tilewidth / 2;
-        destY = -tileheight / 2;
+        x = -tilewidth / 2;
+        y = -tileheight / 2;
       } else if (flipped) {
         context.save();
         context.translate(
@@ -716,18 +712,19 @@ class TileEngine {
           flippedHorizontal ? -1 : 1,
           flippedVertical ? -1 : 1
         );
-        destX = flipped ? 0 : x;
-        destY = flipped ? 0 : y;
+        x = flipped ? 0 : x;
+        y = flipped ? 0 : y;
       }
       // @endif
+
       context.drawImage(
         image,
         sx,
         sy,
         tilewidth,
         tileheight,
-        destX,
-        destY,
+        x,
+        y,
         tilewidth,
         tileheight
       );

--- a/test/unit/tileEngine.spec.js
+++ b/test/unit/tileEngine.spec.js
@@ -1087,6 +1087,110 @@ describe(
             )
           ).to.be.true;
         });
+
+        it('a tile flipped and turned clockwise', () => {
+          let tileEngine = TileEngine({
+            tilewidth: 10,
+            tileheight: 10,
+            width: 1,
+            height: 1,
+            tilesets: [
+              {
+                firstgid: 1,
+                image: new Image(),
+                columns: 10
+              }
+            ],
+            layers: [
+              {
+                name: 'test',
+                data: [3 + 0x80000000 + 0x40000000 + 0x20000000]
+              }
+            ]
+          });
+
+          let r = tileEngine._r.bind(tileEngine);
+          let ctx;
+          tileEngine._r = function overrideR(layer, context) {
+            ctx = context;
+            sinon.stub(context, 'drawImage').callsFake(noop);
+            sinon.stub(context, 'translate').callsFake(noop);
+            sinon.stub(context, 'scale').callsFake(noop);
+            sinon.stub(context, 'rotate').callsFake(noop);
+            r(layer, context);
+          };
+
+          tileEngine.renderLayer('test');
+
+          expect(ctx.translate.calledWith(5, 5)).to.be.true;
+          expect(ctx.rotate.calledWith(Math.PI / 2)).to.be.true;
+          expect(ctx.scale.calledWith(-1, 1)).to.be.true;
+          expect(
+            ctx.drawImage.calledWith(
+              tileEngine.tilesets[0].image,
+              20,
+              0,
+              10,
+              10,
+              -5,
+              -5,
+              10,
+              10
+            )
+          ).to.be.true;
+        });
+
+        it('a tile flipped and turned anticlockwise', () => {
+          let tileEngine = TileEngine({
+            tilewidth: 10,
+            tileheight: 10,
+            width: 1,
+            height: 1,
+            tilesets: [
+              {
+                firstgid: 1,
+                image: new Image(),
+                columns: 10
+              }
+            ],
+            layers: [
+              {
+                name: 'test',
+                data: [3 + 0x20000000]
+              }
+            ]
+          });
+
+          let r = tileEngine._r.bind(tileEngine);
+          let ctx;
+          tileEngine._r = function overrideR(layer, context) {
+            ctx = context;
+            sinon.stub(context, 'drawImage').callsFake(noop);
+            sinon.stub(context, 'translate').callsFake(noop);
+            sinon.stub(context, 'scale').callsFake(noop);
+            sinon.stub(context, 'rotate').callsFake(noop);
+            r(layer, context);
+          };
+
+          tileEngine.renderLayer('test');
+
+          expect(ctx.translate.calledWith(5, 5)).to.be.true;
+          expect(ctx.rotate.calledWith(-Math.PI / 2)).to.be.true;
+          expect(ctx.scale.calledWith(-1, 1)).to.be.true;
+          expect(
+            ctx.drawImage.calledWith(
+              tileEngine.tilesets[0].image,
+              20,
+              0,
+              10,
+              10,
+              -5,
+              -5,
+              10,
+              10
+            )
+          ).to.be.true;
+        });
       } else {
         it('does not rotate tile', () => {
           let tileEngine = TileEngine({


### PR DESCRIPTION
Hello @straker 

The last update about flipping vertically or horizontally don't cover all cases. Indeed, if a tile is rotated 90° clockwise or anticlockwise, Tiled use bits 30.

I implemented that feature. I hope to have carefuly follow your coding style and do the thing the right way. 

I'm open to your feedback about my PR.

regards

@sdeseille