### PR TITLE
fix(spriteSheet): actually default margin and spacing to 0

### DIFF
--- a/src/spriteSheet.js
+++ b/src/spriteSheet.js
@@ -94,8 +94,8 @@ class SpriteSheet {
     image,
     frameWidth,
     frameHeight,
-    spacing,
-    margin,
+    spacing = 0,
+    margin = 0,
     animations
   } = {}) {
     // @ifdef DEBUG

--- a/test/unit/spriteSheet.spec.js
+++ b/test/unit/spriteSheet.spec.js
@@ -54,6 +54,18 @@ describe('spriteSheet', () => {
       expect(SpriteSheetClass.prototype.createAnimations.called).to.be
         .true;
     });
+
+    it('should default margin and spacing to 0', () => {
+      let spriteSheet = SpriteSheet({
+        image: new Image(100, 200),
+        frameWidth: 10,
+        frameHeight: 10
+      });
+
+      expect(spriteSheet.frame.margin).to.equal(0);
+      expect(spriteSheet.frame.spacing).to.equal(0);
+      expect(spriteSheet._f).to.equal(10);
+    });
   });
 
   // --------------------------------------------------


### PR DESCRIPTION
Turns out I forgot to actually default the props to 0 in the code, so not passing them caused the animation to never update.