### PR TITLE
fix(GameObject): render properly when tracked by pointer

### DIFF
--- a/src/pointer.js
+++ b/src/pointer.js
@@ -442,12 +442,12 @@ export function track(...objects) {
 
     // override the objects render function to keep track of render
     // order
-    if (!object._r) {
-      object._r = object.render;
+    if (!object.__r) {
+      object.__r = object.render;
 
       object.render = function () {
         pointer._cf.push(this);
-        this._r();
+        this.__r();
       };
 
       pointer._o.push(object);
@@ -483,8 +483,8 @@ export function untrack(...objects) {
 
     // restore original render function to no longer track render
     // order
-    object.render = object._r;
-    object._r = 0; // 0 is the shortest falsy value
+    object.render = object.__r;
+    object.__r = 0; // 0 is the shortest falsy value
 
     removeFromArray(pointer._o, object);
   });

--- a/test/integration/sprite.spec.js
+++ b/test/integration/sprite.spec.js
@@ -1,5 +1,6 @@
 import Sprite from '../../src/sprite.js';
 import SpriteSheet from '../../src/spriteSheet.js';
+import { track, initPointer } from '../../src/pointer.js';
 
 describe('sprite integration', () => {
   it('should clone spriteSheet animations to prevent frame corruption ', () => {
@@ -76,5 +77,26 @@ describe('sprite integration', () => {
     expect(sprite1.animations.walk._f).to.equal(3);
     expect(sprite2.animations.walk._f).to.equal(0);
     expect(sprite3.animations.walk._f).to.equal(0);
+  });
+
+  it('should render when tracked by pointer', () => {
+    initPointer();
+    let spy = sinon.spy();
+
+    let sprite = Sprite({
+      x: 100,
+      y: 200,
+      color: 'red',
+      render: spy
+    });
+
+    track(sprite);
+    sprite.render();
+
+    // retain _r as radius
+    expect(typeof sprite._r).to.not.equal('function');
+
+    // retain _rf as render function
+    expect(sprite._rf).to.equal(spy);
   });
 });

--- a/test/unit/pointer.spec.js
+++ b/test/unit/pointer.spec.js
@@ -166,7 +166,7 @@ describe('pointer', () => {
       pointer.track(obj);
 
       expect(obj.render).to.not.equal(noop);
-      expect(obj._r).to.exist;
+      expect(obj.__r).to.exist;
     });
 
     it('should take multiple objects', () => {
@@ -175,9 +175,9 @@ describe('pointer', () => {
       pointer.track(obj, obj2);
 
       expect(obj.render).to.not.equal(noop);
-      expect(obj._r).to.exist;
+      expect(obj.__r).to.exist;
       expect(obj2.render).to.not.equal(noop);
-      expect(obj2._r).to.exist;
+      expect(obj2.__r).to.exist;
     });
 
     it('should take an array of objects', () => {
@@ -186,9 +186,9 @@ describe('pointer', () => {
       pointer.track([obj, obj2]);
 
       expect(obj.render).to.not.equal(noop);
-      expect(obj._r).to.exist;
+      expect(obj.__r).to.exist;
       expect(obj2.render).to.not.equal(noop);
-      expect(obj2._r).to.exist;
+      expect(obj2.__r).to.exist;
     });
 
     it('should call the objects original render function', () => {
@@ -207,13 +207,13 @@ describe('pointer', () => {
       function func() {
         pointer.track(obj);
 
-        render = obj._r;
+        render = obj.__r;
 
         pointer.track(obj);
       }
 
       expect(func).to.not.throw();
-      expect(render).to.equal(obj._r);
+      expect(render).to.equal(obj.__r);
     });
 
     it('should track objects separately for each canvas', () => {
@@ -254,7 +254,7 @@ describe('pointer', () => {
       pointer.untrack(obj);
 
       expect(obj.render).to.equal(noop);
-      expect(obj._r).to.not.be.true;
+      expect(obj.__r).to.not.be.true;
     });
 
     it('should take multiple objects', () => {
@@ -264,9 +264,9 @@ describe('pointer', () => {
       pointer.untrack(obj, obj2);
 
       expect(obj.render).to.equal(noop);
-      expect(obj._r).to.not.be.true;
+      expect(obj.__r).to.not.be.true;
       expect(obj2.render).to.equal(noop);
-      expect(obj2._r).to.not.be.true;
+      expect(obj2.__r).to.not.be.true;
     });
 
     it('should take an array objects', () => {
@@ -276,9 +276,9 @@ describe('pointer', () => {
       pointer.untrack([obj, obj2]);
 
       expect(obj.render).to.equal(noop);
-      expect(obj._r).to.not.be.true;
+      expect(obj.__r).to.not.be.true;
       expect(obj2.render).to.equal(noop);
-      expect(obj2._r).to.not.be.true;
+      expect(obj2.__r).to.not.be.true;
     });
 
     it('should do nothing if the object was never tracked', () => {


### PR DESCRIPTION
When I added the [code to handle sprites as circles](#317) I accidentally created a name collision with the pointer render override function. I also had the same problem in the TIleEngine and [had to change it there as well](https://github.com/straker/kontra/pull/407/files#diff-c13f3e44d0ab1165381f057bf876cfcaa8adc659e1e8fdb26b5610e9a11ed446R688). To prevent this problem in the future I changed the pointer override to a double underscore instead of using a single one as I don't use double underscore for private variables.