### PR TITLE
fix: only call init functions of objects once 

### DIFF
--- a/docs/service-worker.js
+++ b/docs/service-worker.js
@@ -18,7 +18,7 @@ const filesToCache = [
   `${prefix}/assets/styles.css`
 ];
 
-const staticCacheName = 'kontra-docs-v10.0.0';
+const staticCacheName = 'kontra-docs-v10.0.2';
 
 // cache the application shell
 self.addEventListener('install', event => {

--- a/src/button.js
+++ b/src/button.js
@@ -134,6 +134,7 @@ class Button extends SpriteClass {
    */
   destroy() {
     this._dn.remove();
+    this.textNode.destroy();
   }
 
   _p() {

--- a/src/events.js
+++ b/src/events.js
@@ -45,10 +45,11 @@ export function on(event, callback, once = false) {
  *
  * @param {String} event - Name of the event.
  * @param {Function} callback - The function that was passed during registration.
+ * @param {Boolean} [once=false] - If the callback was added as a one time function or not.
  */
-export function off(event, callback) {
+export function off(event, callback, once = false) {
   callbacks[event] = (callbacks[event] || []).filter(
-    ({ fn }) => fn != callback
+    ({ fn, once: _once }) => !(fn == callback && _once == once)
   );
 }
 
@@ -63,7 +64,7 @@ export function emit(event, ...args) {
   (callbacks[event] || []).map(({ fn, once }) => {
     fn(...args);
     if (once) {
-      off(event, fn);
+      off(event, fn, once);
     }
   });
 }

--- a/src/events.js
+++ b/src/events.js
@@ -32,21 +32,11 @@ export let callbacks = {};
  *
  * @param {String} event - Name of the event.
  * @param {Function} callback - Function that will be called when the event is emitted.
+ * @param {Boolean} [once=false] - If the callback should only be called the first time the event is emitted.
  */
 export function on(event, callback, once = false) {
   callbacks[event] = callbacks[event] || [];
   callbacks[event].push({ fn: callback, once });
-}
-
-/**
- * Register a callback for an event to be called only the first time the event is emitted. The callback will be passed all arguments used in the `emit` call.
- * @function once
- *
- * @param {String} event - Name of the event.
- * @param {Function} callback - Function that will be called only the first time the event is emitted.
- */
-export function once(event, callback) {
-  on(event, callback, true);
 }
 
 /**

--- a/src/gameLoop.js
+++ b/src/gameLoop.js
@@ -1,5 +1,5 @@
 import { noop } from './utils.js';
-import { emit, once } from './events.js';
+import { emit, on } from './events.js';
 import { getContext } from './core.js';
 
 /**
@@ -87,9 +87,13 @@ export default function GameLoop({
     });
   }
 
-  once('init', () => {
-    loop.context ??= getContext();
-  });
+  on(
+    'init',
+    () => {
+      loop.context ??= getContext();
+    },
+    true
+  );
 
   /**
    * Called every frame of the game loop.

--- a/src/gameLoop.js
+++ b/src/gameLoop.js
@@ -1,5 +1,5 @@
 import { noop } from './utils.js';
-import { emit, on } from './events.js';
+import { emit, once } from './events.js';
 import { getContext } from './core.js';
 
 /**
@@ -87,7 +87,7 @@ export default function GameLoop({
     });
   }
 
-  on('init', () => {
+  once('init', () => {
     loop.context ??= getContext();
   });
 

--- a/src/gameObject.js
+++ b/src/gameObject.js
@@ -1,6 +1,6 @@
 import { getContext } from './core.js';
 import Updatable from './updatable.js';
-import { once } from './events.js';
+import { on } from './events.js';
 import { rotatePoint, clamp } from './helpers.js';
 import { noop, removeFromArray } from './utils.js';
 
@@ -267,9 +267,13 @@ class GameObject extends Updatable {
     // uf = update function
     this._uf = update;
 
-    once('init', () => {
-      this.context ??= getContext();
-    });
+    on(
+      'init',
+      () => {
+        this.context ??= getContext();
+      },
+      true
+    );
   }
 
   /**

--- a/src/gameObject.js
+++ b/src/gameObject.js
@@ -1,6 +1,6 @@
 import { getContext } from './core.js';
 import Updatable from './updatable.js';
-import { on } from './events.js';
+import { on, off } from './events.js';
 import { rotatePoint, clamp } from './helpers.js';
 import { noop, removeFromArray } from './utils.js';
 
@@ -267,13 +267,22 @@ class GameObject extends Updatable {
     // uf = update function
     this._uf = update;
 
-    on(
-      'init',
-      () => {
-        this.context ??= getContext();
-      },
-      true
-    );
+    // in = init
+    this._in = () => {
+      this.context ??= getContext();
+    };
+    if (!this.context) {
+      on('init', this._in, true);
+    }
+  }
+
+  /**
+   * Clean up the GameObject object.
+   * @memberof Text
+   * @function destroy
+   */
+  destroy() {
+    off('init', this._in, true);
   }
 
   /**

--- a/src/gameObject.js
+++ b/src/gameObject.js
@@ -1,6 +1,6 @@
 import { getContext } from './core.js';
 import Updatable from './updatable.js';
-import { on } from './events.js';
+import { once } from './events.js';
 import { rotatePoint, clamp } from './helpers.js';
 import { noop, removeFromArray } from './utils.js';
 
@@ -267,7 +267,7 @@ class GameObject extends Updatable {
     // uf = update function
     this._uf = update;
 
-    on('init', () => {
+    once('init', () => {
       this.context ??= getContext();
     });
   }

--- a/src/scene.js
+++ b/src/scene.js
@@ -1,6 +1,6 @@
 import { getContext } from './core.js';
 import { GameObjectClass } from './gameObject.js';
-import { once, off } from './events.js';
+import { on, off } from './events.js';
 import {
   srOnlyStyle,
   focusParams,
@@ -218,7 +218,7 @@ class Scene {
       this._i();
     }
 
-    once('init', this._i);
+    on('init', this._i, true);
   }
 
   set objects(value) {

--- a/src/scene.js
+++ b/src/scene.js
@@ -1,6 +1,6 @@
 import { getContext } from './core.js';
 import { GameObjectClass } from './gameObject.js';
-import { on, off } from './events.js';
+import { once, off } from './events.js';
 import {
   srOnlyStyle,
   focusParams,
@@ -218,7 +218,7 @@ class Scene {
       this._i();
     }
 
-    on('init', this._i);
+    once('init', this._i);
   }
 
   set objects(value) {

--- a/src/scene.js
+++ b/src/scene.js
@@ -216,9 +216,9 @@ class Scene {
 
     if (this.context) {
       this._i();
+    } else {
+      on('init', this._i, true);
     }
-
-    on('init', this._i, true);
   }
 
   set objects(value) {
@@ -317,9 +317,10 @@ class Scene {
    * @function destroy
    */
   destroy() {
-    off('init', this._i);
+    off('init', this._i, true);
     this._dn.remove();
     this._o.map(object => object.destroy && object.destroy());
+    this.camera.destroy();
   }
 
   /**

--- a/src/text.js
+++ b/src/text.js
@@ -1,5 +1,5 @@
 import { GameObjectClass } from './gameObject.js';
-import { once } from './events.js';
+import { on } from './events.js';
 import { getContext } from './core.js';
 
 let fontSizeRegex = /(\d+)(\w+)/;
@@ -120,10 +120,14 @@ class Text extends GameObjectClass {
       this._p();
     }
 
-    once('init', () => {
-      this.font ??= getContext().font;
-      this._p();
-    });
+    on(
+      'init',
+      () => {
+        this.font ??= getContext().font;
+        this._p();
+      },
+      true
+    );
   }
 
   // keep width and height getters/settings so we can set _w and _h

--- a/src/text.js
+++ b/src/text.js
@@ -1,5 +1,5 @@
 import { GameObjectClass } from './gameObject.js';
-import { on } from './events.js';
+import { once } from './events.js';
 import { getContext } from './core.js';
 
 let fontSizeRegex = /(\d+)(\w+)/;
@@ -120,7 +120,7 @@ class Text extends GameObjectClass {
       this._p();
     }
 
-    on('init', () => {
+    once('init', () => {
       this.font ??= getContext().font;
       this._p();
     });
@@ -266,7 +266,6 @@ class Text extends GameObjectClass {
       context.textAlign = textAlign;
       context.fillStyle = this.color;
       context.font = this.font;
-
 
       // @ifdef TEXT_STROKE
       if (this.strokeColor) {

--- a/src/text.js
+++ b/src/text.js
@@ -1,5 +1,5 @@
 import { GameObjectClass } from './gameObject.js';
-import { on } from './events.js';
+import { on, off } from './events.js';
 import { getContext } from './core.js';
 
 let fontSizeRegex = /(\d+)(\w+)/;
@@ -115,19 +115,18 @@ class Text extends GameObjectClass {
       ...props
     });
 
+    // i = init
+    this._i = () => {
+      this.font ??= getContext().font;
+      this._p();
+    };
+
     // p = prerender
     if (this.context) {
-      this._p();
+      this._i();
+    } else {
+      on('init', this._i, true);
     }
-
-    on(
-      'init',
-      () => {
-        this.font ??= getContext().font;
-        this._p();
-      },
-      true
-    );
   }
 
   // keep width and height getters/settings so we can set _w and _h
@@ -173,6 +172,16 @@ class Text extends GameObjectClass {
   set lineHeight(value) {
     this._d = true;
     this._lh = value;
+  }
+
+  /**
+   * Clean up the Text object.
+   * @memberof Text
+   * @function destroy
+   */
+  destroy() {
+    super.destroy();
+    off('init', this._i, true);
   }
 
   render() {

--- a/src/text.js
+++ b/src/text.js
@@ -118,10 +118,10 @@ class Text extends GameObjectClass {
     // i = init
     this._i = () => {
       this.font ??= getContext().font;
+      // p = prerender
       this._p();
     };
 
-    // p = prerender
     if (this.context) {
       this._i();
     } else {

--- a/src/tileEngine.js
+++ b/src/tileEngine.js
@@ -1,5 +1,5 @@
 import { getCanvas, getContext } from './core.js';
-import { on } from './events.js';
+import { on, off } from './events.js';
 import { clamp, getWorldRect } from './helpers.js';
 import { removeFromArray } from './utils.js';
 
@@ -230,19 +230,27 @@ class TileEngine {
       ...properties
     });
 
+    // i = init
+    this._i = () => {
+      this.context ??= getContext();
+      this._p();
+    };
+
     // p = prerender
     if (this.context) {
-      this._p();
+      this._i();
+    } else {
+      on('init', this._i, true);
     }
+  }
 
-    on(
-      'init',
-      () => {
-        this.context ??= getContext();
-        this._p();
-      },
-      true
-    );
+  /**
+   * Clean up the TileEngine object.
+   * @memberof TileEngine
+   * @function destroy
+   */
+  destroy() {
+    off('init', this._i, true);
   }
 
   // @ifdef TILEENGINE_CAMERA

--- a/src/tileEngine.js
+++ b/src/tileEngine.js
@@ -1,5 +1,5 @@
 import { getCanvas, getContext } from './core.js';
-import { on } from './events.js';
+import { once } from './events.js';
 import { clamp, getWorldRect } from './helpers.js';
 import { removeFromArray } from './utils.js';
 
@@ -235,7 +235,7 @@ class TileEngine {
       this._p();
     }
 
-    on('init', () => {
+    once('init', () => {
       this.context ??= getContext();
       this._p();
     });

--- a/src/tileEngine.js
+++ b/src/tileEngine.js
@@ -1,5 +1,5 @@
 import { getCanvas, getContext } from './core.js';
-import { once } from './events.js';
+import { on } from './events.js';
 import { clamp, getWorldRect } from './helpers.js';
 import { removeFromArray } from './utils.js';
 
@@ -235,10 +235,14 @@ class TileEngine {
       this._p();
     }
 
-    once('init', () => {
-      this.context ??= getContext();
-      this._p();
-    });
+    on(
+      'init',
+      () => {
+        this.context ??= getContext();
+        this._p();
+      },
+      true
+    );
   }
 
   // @ifdef TILEENGINE_CAMERA

--- a/src/tileEngine.js
+++ b/src/tileEngine.js
@@ -233,10 +233,10 @@ class TileEngine {
     // i = init
     this._i = () => {
       this.context ??= getContext();
+      // p = prerender
       this._p();
     };
 
-    // p = prerender
     if (this.context) {
       this._i();
     } else {

--- a/test/typings/events.ts
+++ b/test/typings/events.ts
@@ -3,9 +3,6 @@ import * as kontra from '../../kontra.js';
 kontra.on('myEvent', () => {
   console.log('fired!');
 });
-kontra.once('myEvent', () => {
-  console.log('fired!');
-});
 kontra.off('myEvent', () => {});
 kontra.emit('myEvent');
 
@@ -13,7 +10,7 @@ kontra.emit('myEvent');
 kontra.on('myEvent', (num, str, bool, obj) => {
   console.log({num, str, bool, obj});
 });
-kontra.once('myEvent', (num, str, bool, obj) => {
+kontra.on('myEvent', (num, str, bool, obj) => {
   console.log({num, str, bool, obj});
-});
+}, true);
 kontra.emit('myEvent', 1, 'string', true, {});

--- a/test/typings/events.ts
+++ b/test/typings/events.ts
@@ -3,11 +3,17 @@ import * as kontra from '../../kontra.js';
 kontra.on('myEvent', () => {
   console.log('fired!');
 });
+kontra.once('myEvent', () => {
+  console.log('fired!');
+});
 kontra.off('myEvent', () => {});
 kontra.emit('myEvent');
 
 // args
 kontra.on('myEvent', (num, str, bool, obj) => {
+  console.log({num, str, bool, obj});
+});
+kontra.once('myEvent', (num, str, bool, obj) => {
   console.log({num, str, bool, obj});
 });
 kontra.emit('myEvent', 1, 'string', true, {});

--- a/test/typings/gameObject.ts
+++ b/test/typings/gameObject.ts
@@ -51,6 +51,7 @@ gameObject.render();
 gameObject.draw();
 gameObject.setScale(1);
 gameObject.setScale(1, 2);
+gameObject.destroy();
 
 // options
 kontra.GameObject({

--- a/test/typings/text.ts
+++ b/test/typings/text.ts
@@ -20,6 +20,7 @@ text.x += 20;
 text.rotation = Math.PI;
 text.advance();
 text.render();
+text.destroy();
 
 // options
 kontra.Text({

--- a/test/typings/tileEngine.ts
+++ b/test/typings/tileEngine.ts
@@ -56,6 +56,7 @@ const { x, y, row, col } = tileEngine.getPosition({x: 100, y: 200})
 tileEngine.getPosition({x: 100, y: 200} as PointerEvent)
 tileEngine.setTileAtLayer('ground', { x, y }, 5);
 tileEngine.setTileAtLayer('ground', { row, col }, 5);
+tileEngine.destroy();
 
 // options
 kontra.TileEngine({

--- a/test/unit/button.spec.js
+++ b/test/unit/button.spec.js
@@ -263,6 +263,13 @@ describe('button', () => {
 
       expect(document.body.contains(button._dn)).to.be.false;
     });
+
+    it('should call destroy on the textNode', () => {
+      sinon.spy(button.textNode, 'destroy');
+      button.destroy();
+
+      expect(button.textNode.destroy.called).to.be.true;
+    });
   });
 
   // --------------------------------------------------

--- a/test/unit/events.spec.js
+++ b/test/unit/events.spec.js
@@ -163,6 +163,46 @@ describe('events', () => {
       });
     });
 
+    it('should remove callback added as once', () => {
+      delete events.callbacks.foo;
+
+      function func2() {}
+      events.on('foo', func2, true);
+
+      expect(events.callbacks.foo.length).to.equal(1);
+
+      events.off('foo', func2, true);
+
+      expect(events.callbacks.foo.length).to.equal(0);
+    });
+
+    it('should not remove callback added as once if not passed once param', () => {
+      delete events.callbacks.foo;
+
+      function func2() {}
+      events.on('foo', func2, true);
+
+      expect(events.callbacks.foo.length).to.equal(1);
+
+      events.off('foo', func2);
+
+      expect(events.callbacks.foo.length).to.equal(1);
+    });
+
+    it('should only remove callback that matches once param', () => {
+      events.on('foo', func, true);
+
+      expect(events.callbacks.foo.length).to.equal(2);
+
+      events.off('foo', func, true);
+
+      expect(events.callbacks.foo.length).to.equal(1);
+      expect(events.callbacks.foo[0]).to.deep.equal({
+        fn: func,
+        once: false
+      });
+    });
+
     it('should not error if the callback was not added before', () => {
       function fn() {
         events.off('foo', () => {});

--- a/test/unit/events.spec.js
+++ b/test/unit/events.spec.js
@@ -23,7 +23,10 @@ describe('events', () => {
       events.on('foo', func);
 
       expect(events.callbacks.foo).to.be.an('array');
-      expect(events.callbacks.foo[0]).to.equal(func);
+      expect(events.callbacks.foo[0]).to.deep.equal({
+        fn: func,
+        once: false
+      });
     });
 
     it('should append the event if it already exists', () => {
@@ -33,8 +36,91 @@ describe('events', () => {
       events.on('foo', func2);
 
       expect(events.callbacks.foo).to.be.an('array');
-      expect(events.callbacks.foo[0]).to.equal(func1);
-      expect(events.callbacks.foo[1]).to.equal(func2);
+      expect(events.callbacks.foo[0]).to.deep.equal({
+        fn: func1,
+        once: false
+      });
+      expect(events.callbacks.foo[1]).to.deep.equal({
+        fn: func2,
+        once: false
+      });
+    });
+  });
+
+  // --------------------------------------------------
+  // once
+  // --------------------------------------------------
+  describe('once', () => {
+    afterEach(() => {
+      delete events.callbacks.foo;
+    });
+
+    it('should add the event to the callbacks object', () => {
+      function func() {}
+      events.once('foo', func);
+
+      expect(events.callbacks.foo).to.be.an('array');
+      expect(events.callbacks.foo[0]).to.deep.equal({
+        fn: func,
+        once: true
+      });
+    });
+
+    it('should append the event if it already exists', () => {
+      function func1() {}
+      function func2() {}
+      events.once('foo', func1);
+      events.once('foo', func2);
+
+      expect(events.callbacks.foo).to.be.an('array');
+      expect(events.callbacks.foo[0]).to.deep.equal({
+        fn: func1,
+        once: true
+      });
+      expect(events.callbacks.foo[1]).to.deep.equal({
+        fn: func2,
+        once: true
+      });
+    });
+
+    it('should remove the event after emit', () => {
+      let func = sinon.spy();
+      events.once('foo', func);
+      expect(events.callbacks.foo[0]).to.deep.equal({
+        fn: func,
+        once: true
+      });
+
+      events.emit('foo');
+      expect(func.called).to.equal(true);
+      expect(events.callbacks.foo.length).to.equal(0);
+    });
+
+    it('should call multiple functions with mix once type', () => {
+      let func1 = sinon.spy();
+      let func2 = sinon.spy();
+      let func3 = sinon.spy();
+      let func4 = sinon.spy();
+      events.on('foo', func1);
+      events.once('foo', func2);
+      events.on('foo', func3);
+      events.once('foo', func4);
+
+      events.emit('foo');
+      expect(func1.called).to.equal(true);
+      expect(func2.called).to.equal(true);
+      expect(func3.called).to.equal(true);
+      expect(func4.called).to.equal(true);
+
+      expect(events.callbacks.foo.length).to.equal(2);
+      expect(events.callbacks.foo[0]).to.deep.equal({
+        fn: func1,
+        once: false
+      });
+      expect(events.callbacks.foo[1]).to.deep.equal({
+        fn: func3,
+        once: false
+      });
     });
   });
 
@@ -67,8 +153,14 @@ describe('events', () => {
       events.off('foo', func);
 
       expect(events.callbacks.foo.length).to.equal(2);
-      expect(events.callbacks.foo[0]).to.equal(func1);
-      expect(events.callbacks.foo[1]).to.equal(func2);
+      expect(events.callbacks.foo[0]).to.deep.equal({
+        fn: func1,
+        once: false
+      });
+      expect(events.callbacks.foo[1]).to.deep.equal({
+        fn: func2,
+        once: false
+      });
     });
 
     it('should not error if the callback was not added before', () => {

--- a/test/unit/events.spec.js
+++ b/test/unit/events.spec.js
@@ -48,16 +48,16 @@ describe('events', () => {
   });
 
   // --------------------------------------------------
-  // once
+  // on(once)
   // --------------------------------------------------
-  describe('once', () => {
+  describe('on(once)', () => {
     afterEach(() => {
       delete events.callbacks.foo;
     });
 
     it('should add the event to the callbacks object', () => {
       function func() {}
-      events.once('foo', func);
+      events.on('foo', func, true);
 
       expect(events.callbacks.foo).to.be.an('array');
       expect(events.callbacks.foo[0]).to.deep.equal({
@@ -69,8 +69,8 @@ describe('events', () => {
     it('should append the event if it already exists', () => {
       function func1() {}
       function func2() {}
-      events.once('foo', func1);
-      events.once('foo', func2);
+      events.on('foo', func1, true);
+      events.on('foo', func2, true);
 
       expect(events.callbacks.foo).to.be.an('array');
       expect(events.callbacks.foo[0]).to.deep.equal({
@@ -85,7 +85,7 @@ describe('events', () => {
 
     it('should remove the event after emit', () => {
       let func = sinon.spy();
-      events.once('foo', func);
+      events.on('foo', func, true);
       expect(events.callbacks.foo[0]).to.deep.equal({
         fn: func,
         once: true
@@ -102,9 +102,9 @@ describe('events', () => {
       let func3 = sinon.spy();
       let func4 = sinon.spy();
       events.on('foo', func1);
-      events.once('foo', func2);
+      events.on('foo', func2, true);
       events.on('foo', func3);
-      events.once('foo', func4);
+      events.on('foo', func4, true);
 
       events.emit('foo');
       expect(func1.called).to.equal(true);

--- a/test/unit/gameLoop.spec.js
+++ b/test/unit/gameLoop.spec.js
@@ -56,6 +56,26 @@ describe('gameLoop', () => {
 
       expect(loop.context).to.equal(true);
     });
+
+    it('should remove init callback', () => {
+      _reset();
+
+      let loop = GameLoop({
+        render: noop
+      });
+
+      expect(loop.context).to.be.undefined;
+
+      let canvas = document.createElement('canvas');
+      canvas.width = canvas.height = 600;
+      init(canvas);
+
+      expect(loop.context).to.equal(canvas.getContext('2d'));
+      delete loop.context;
+      init(canvas);
+
+      expect(loop.context).to.be.undefined;
+    });
   });
 
   // --------------------------------------------------

--- a/test/unit/gameObject.spec.js
+++ b/test/unit/gameObject.spec.js
@@ -110,6 +110,24 @@ describe(
         expect(gameObject.context).to.equal(true);
       });
 
+      it('should remove init callback', () => {
+        _reset();
+
+        gameObject = GameObject();
+
+        expect(gameObject.context).to.be.undefined;
+
+        let canvas = document.createElement('canvas');
+        canvas.width = canvas.height = 600;
+        init(canvas);
+
+        expect(gameObject.context).to.equal(canvas.getContext('2d'));
+        delete gameObject.context;
+        init(canvas);
+
+        expect(gameObject.context).to.be.undefined;
+      });
+
       if (testContext.GAMEOBJECT_ANCHOR) {
         it('should set default anchor', () => {
           expect(gameObject.anchor).to.deep.equal({ x: 0, y: 0 });

--- a/test/unit/scene.spec.js
+++ b/test/unit/scene.spec.js
@@ -5,7 +5,11 @@ import {
   getContext,
   getCanvas
 } from '../../src/core.js';
-import { emit } from '../../src/events.js';
+import {
+  emit,
+  callbacks,
+  _reset as resetEvents
+} from '../../src/events.js';
 import { noop, srOnlyStyle } from '../../src/utils.js';
 import { collides } from '../../src/helpers.js';
 
@@ -234,6 +238,22 @@ describe('scene', () => {
 
       expect(scene._dn.isConnected).to.be.true;
       expect(scene.camera.centerX).to.exist;
+    });
+
+    it("should not add init callback if already init'd", () => {
+      scene.destroy();
+      _reset();
+      resetEvents();
+
+      let canvas = document.createElement('canvas');
+      canvas.width = canvas.height = 600;
+      init(canvas);
+
+      scene = Scene({
+        id: 'myId'
+      });
+
+      expect(callbacks.init).to.be.undefined;
     });
   });
 
@@ -546,6 +566,30 @@ describe('scene', () => {
       emit('init');
 
       expect(section.isConnected).to.be.false;
+    });
+
+    it('should call destroy on camera', () => {
+      sinon.spy(scene.camera, 'destroy');
+
+      scene.destroy();
+
+      expect(scene.camera.destroy.called).to.be.true;
+    });
+
+    it('should clean up init event', () => {
+      scene.destroy();
+      _reset();
+      resetEvents();
+
+      scene = Scene({
+        id: 'myId'
+      });
+      expect(scene.context).to.be.undefined;
+
+      scene.destroy();
+      emit('init');
+
+      expect(scene.context).to.be.undefined;
     });
   });
 

--- a/test/unit/scene.spec.js
+++ b/test/unit/scene.spec.js
@@ -199,6 +199,27 @@ describe('scene', () => {
       expect(scene.context).to.equal(context);
     });
 
+    it('should remove init callback', () => {
+      _reset();
+
+      scene.destroy();
+      scene = Scene({
+        id: 'myId'
+      });
+
+      expect(scene.context).to.be.undefined;
+
+      let canvas = document.createElement('canvas');
+      canvas.width = canvas.height = 600;
+      init(canvas);
+
+      expect(scene.context).to.equal(canvas.getContext('2d'));
+      delete scene.context;
+      init(canvas);
+
+      expect(scene.context).to.be.undefined;
+    });
+
     it('should add dom node to body and set camera if kontra.init is called after created', () => {
       _reset();
 

--- a/test/unit/text.spec.js
+++ b/test/unit/text.spec.js
@@ -1,5 +1,10 @@
 import Text, { TextClass } from '../../src/text.js';
 import { _reset, init, getContext } from '../../src/core.js';
+import {
+  callbacks,
+  _reset as resetEvents,
+  emit
+} from '../../src/events.js';
 
 // test-context:start
 let testContext = {
@@ -157,6 +162,37 @@ describe(
         expect(text._f).to.exist;
         delete text._f;
         init(canvas);
+
+        expect(text._f).to.be.undefined;
+      });
+
+      it("should not add init callback if already init'd", () => {
+        _reset();
+        resetEvents();
+
+        let canvas = document.createElement('canvas');
+        canvas.width = canvas.height = 600;
+        init(canvas);
+
+        Text({ text: '' });
+
+        expect(callbacks.init).to.be.undefined;
+      });
+    });
+
+    // --------------------------------------------------
+    // destroy
+    // --------------------------------------------------
+    describe('destroy', () => {
+      it('should clean up init event', () => {
+        _reset();
+        resetEvents();
+
+        let text = Text({ text: '' });
+        expect(text._f).to.be.undefined;
+
+        text.destroy();
+        emit('init');
 
         expect(text._f).to.be.undefined;
       });

--- a/test/unit/text.spec.js
+++ b/test/unit/text.spec.js
@@ -133,7 +133,7 @@ describe(
         expect(text.font).to.equal('42px Arial');
       });
 
-      it('should call prerender if kontra.init is called after created', () => {
+      it('should remove init callback', () => {
         _reset();
 
         let text = Text({ text: '' });
@@ -142,7 +142,27 @@ describe(
         canvas.width = canvas.height = 600;
         init(canvas);
 
-        expect(text._s).to.exist;
+        expect(text._f).to.exist;
+        delete text._f;
+        init(canvas);
+
+        expect(text._f).to.be.undefined;
+      });
+
+      it('should set font if kontra.init is called after created', () => {
+        _reset();
+
+        let text = Text({ text: '' });
+
+        expect(text.font).to.be.undefined;
+
+        let canvas = document.createElement('canvas');
+        canvas.width = canvas.height = 600;
+        let context = canvas.getContext('2d');
+        context.font = '32px Arial';
+        init(canvas);
+
+        expect(text.font).to.equal('32px Arial');
       });
     });
 
@@ -301,8 +321,7 @@ describe(
               'sights'
             ]);
           });
-        }
-        else {
+        } else {
           it('should not calculate new lines and auto new lines', () => {
             let text = Text({
               text: 'Hello\nWorld,\nI must be going to see the\nsights',
@@ -518,8 +537,7 @@ describe(
 
           expect(spy.set.calledWith(2)).to.be.true;
         });
-      }
-      else {
+      } else {
         it('should not call strokeText', () => {
           let text = Text({
             text: 'Hello World',

--- a/test/unit/text.spec.js
+++ b/test/unit/text.spec.js
@@ -133,6 +133,18 @@ describe(
         expect(text.font).to.equal('42px Arial');
       });
 
+      it('should call prerender if kontra.init is called after created', () => {
+        _reset();
+
+        let text = Text({ text: '' });
+
+        let canvas = document.createElement('canvas');
+        canvas.width = canvas.height = 600;
+        init(canvas);
+
+        expect(text._s).to.exist;
+      });
+
       it('should remove init callback', () => {
         _reset();
 
@@ -147,22 +159,6 @@ describe(
         init(canvas);
 
         expect(text._f).to.be.undefined;
-      });
-
-      it('should set font if kontra.init is called after created', () => {
-        _reset();
-
-        let text = Text({ text: '' });
-
-        expect(text.font).to.be.undefined;
-
-        let canvas = document.createElement('canvas');
-        canvas.width = canvas.height = 600;
-        let context = canvas.getContext('2d');
-        context.font = '32px Arial';
-        init(canvas);
-
-        expect(text.font).to.equal('32px Arial');
       });
     });
 

--- a/test/unit/tileEngine.spec.js
+++ b/test/unit/tileEngine.spec.js
@@ -6,6 +6,11 @@ import {
   getCanvas
 } from '../../src/core.js';
 import { noop } from '../../src/utils.js';
+import {
+  callbacks,
+  _reset as resetEvents,
+  emit
+} from '../../src/events.js';
 
 // test-context:start
 let testContext = {
@@ -205,6 +210,69 @@ describe(
         expect(tileEngine.context).to.equal(canvas.getContext('2d'));
         delete tileEngine.context;
         init(canvas);
+
+        expect(tileEngine.context).to.be.undefined;
+      });
+
+      it("should not add init callback if already init'd", () => {
+        _reset();
+        resetEvents();
+
+        let canvas = document.createElement('canvas');
+        canvas.width = canvas.height = 600;
+        init(canvas);
+
+        TileEngine({
+          tilewidth: 10,
+          tileheight: 10,
+          width: 50,
+          height: 50,
+          tilesets: [
+            {
+              image: new Image()
+            }
+          ],
+          layers: [
+            {
+              name: 'test',
+              data: [0, 0, 1, 0, 0]
+            }
+          ]
+        });
+
+        expect(callbacks.init).to.be.undefined;
+      });
+    });
+
+    // --------------------------------------------------
+    // destroy
+    // --------------------------------------------------
+    describe('destroy', () => {
+      it('should clean up init event', () => {
+        _reset();
+        resetEvents();
+
+        let tileEngine = TileEngine({
+          tilewidth: 10,
+          tileheight: 10,
+          width: 50,
+          height: 50,
+          tilesets: [
+            {
+              image: new Image()
+            }
+          ],
+          layers: [
+            {
+              name: 'test',
+              data: [0, 0, 1, 0, 0]
+            }
+          ]
+        });
+        expect(tileEngine.context).to.be.undefined;
+
+        tileEngine.destroy();
+        emit('init');
 
         expect(tileEngine.context).to.be.undefined;
       });

--- a/test/unit/tileEngine.spec.js
+++ b/test/unit/tileEngine.spec.js
@@ -174,6 +174,40 @@ describe(
 
         expect(tileEngine._p.called).to.be.true;
       });
+
+      it('should remove init callback', () => {
+        _reset();
+
+        let tileEngine = TileEngine({
+          tilewidth: 10,
+          tileheight: 10,
+          width: 50,
+          height: 50,
+          tilesets: [
+            {
+              image: new Image()
+            }
+          ],
+          layers: [
+            {
+              name: 'test',
+              data: [0, 0, 1, 0, 0]
+            }
+          ]
+        });
+
+        expect(tileEngine.context).to.be.undefined;
+
+        let canvas = document.createElement('canvas');
+        canvas.width = canvas.height = 600;
+        init(canvas);
+
+        expect(tileEngine.context).to.equal(canvas.getContext('2d'));
+        delete tileEngine.context;
+        init(canvas);
+
+        expect(tileEngine.context).to.be.undefined;
+      });
     });
 
     // --------------------------------------------------
@@ -1560,8 +1594,7 @@ describe(
     // tileEngine.getPosition
     // --------------------------------------------------
     describe('getPosition', () => {
-      let tileEngine,
-       canvas;
+      let tileEngine, canvas;
       beforeEach(() => {
         canvas = getCanvas();
         canvas.style.position = 'absolute';


### PR DESCRIPTION
Add new option to `events.on` to allow removing the event after the first emit. I originally had a separate `once` function for this, but decided it added more space to the library than just reusing the `on` function.

Closes https://github.com/straker/kontra/issues/414